### PR TITLE
turn on docker daemon in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
       - image: circleci/golang:1.12.6
     steps:
       - checkout
+      - setup_remote_docker
       - run: echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
       - run: curl -sL https://git.io/goreleaser | bash
 


### PR DESCRIPTION
Forgot to add this step... https://circleci.com/docs/2.0/building-docker-images/

Signed-off-by: Liam White <liam@tetrate.io>