### PR TITLE
Implement network interfaces logging at exit

### DIFF
--- a/pkg/binary/envoy/debug/node.go
+++ b/pkg/binary/envoy/debug/node.go
@@ -122,7 +122,7 @@ func safeProc(p *process.Process) *proc {
 }
 
 func networkInterfaces(r binary.Runner) error {
-	f, err := os.Create(filepath.Join(r.DebugStore(), "node/network_interface.txt"))
+	f, err := os.Create(filepath.Join(r.DebugStore(), "node/network_interface.json"))
 	if err != nil {
 		return fmt.Errorf("unable to create file to write network interface output to: %v", err)
 	}

--- a/pkg/binary/envoy/debug/node.go
+++ b/pkg/binary/envoy/debug/node.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"text/tabwriter"
 
+	"github.com/shirou/gopsutil/net"
 	"github.com/shirou/gopsutil/process"
 	"github.com/tetratelabs/getenvoy/pkg/binary"
 	"github.com/tetratelabs/getenvoy/pkg/binary/envoy"
@@ -34,6 +35,7 @@ func EnableNodeCollection(r *envoy.Runtime) {
 		return
 	}
 	r.RegisterPreTermination(ps)
+	r.RegisterPreTermination(networkInterfaces)
 }
 
 func ps(r binary.Runner) error {
@@ -117,4 +119,20 @@ func safeProc(p *process.Process) *proc {
 		pMem:     pMem,
 		cmd:      cmd,
 	}
+}
+
+func networkInterfaces(r binary.Runner) error {
+	f, err := os.Create(filepath.Join(r.DebugStore(), "node/network_interface.txt"))
+	if err != nil {
+		return fmt.Errorf("unable to create file to write network interface output to: %v", err)
+	}
+	defer f.Close() //nolint
+
+	is, err := net.Interfaces()
+	if err != nil {
+		return fmt.Errorf("unable to fetch network Interfaces: %v", err)
+	}
+	fmt.Fprintln(f, is) // print with JSON format
+
+	return nil
 }

--- a/pkg/binary/envoy/debug/node_test.go
+++ b/pkg/binary/envoy/debug/node_test.go
@@ -41,3 +41,21 @@ func Test_ps(t *testing.T) {
 		}
 	})
 }
+
+func Test_network_inerfaces(t *testing.T) {
+	t.Run("create non-empty files", func(t *testing.T) {
+		r, _ := envoy.NewRuntime(EnableNodeCollection)
+		defer os.RemoveAll(r.DebugStore() + ".tar.gz")
+		defer os.RemoveAll(r.DebugStore())
+		envoytest.RunKill(r, filepath.Join("testdata", "null.yaml"), time.Second*10)
+
+		path := filepath.Join(r.DebugStore(), "node/network_interface.txt")
+		f, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("error stating %v: %v", path, err)
+		}
+		if f.Size() < 1 {
+			t.Errorf("file %v was empty", path)
+		}
+	})
+}

--- a/pkg/binary/envoy/debug/node_test.go
+++ b/pkg/binary/envoy/debug/node_test.go
@@ -24,38 +24,23 @@ import (
 	"github.com/tetratelabs/getenvoy/pkg/binary/envoytest"
 )
 
-func Test_ps(t *testing.T) {
+func Test_debugging_outputs(t *testing.T) {
 	t.Run("creates non-empty files", func(t *testing.T) {
 		r, _ := envoy.NewRuntime(EnableNodeCollection)
 		defer os.RemoveAll(r.DebugStore() + ".tar.gz")
 		defer os.RemoveAll(r.DebugStore())
 		envoytest.RunKill(r, filepath.Join("testdata", "null.yaml"), time.Second*10)
 
-		path := filepath.Join(r.DebugStore(), "node/ps.txt")
-		f, err := os.Stat(path)
-		if err != nil {
-			t.Errorf("error stating %v: %v", path, err)
-		}
-		if f.Size() < 1 {
-			t.Errorf("file %v was empty", path)
-		}
-	})
-}
-
-func Test_network_inerfaces(t *testing.T) {
-	t.Run("create non-empty files", func(t *testing.T) {
-		r, _ := envoy.NewRuntime(EnableNodeCollection)
-		defer os.RemoveAll(r.DebugStore() + ".tar.gz")
-		defer os.RemoveAll(r.DebugStore())
-		envoytest.RunKill(r, filepath.Join("testdata", "null.yaml"), time.Second*10)
-
-		path := filepath.Join(r.DebugStore(), "node/network_interface.txt")
-		f, err := os.Stat(path)
-		if err != nil {
-			t.Errorf("error stating %v: %v", path, err)
-		}
-		if f.Size() < 1 {
-			t.Errorf("file %v was empty", path)
+		files := [...]string{"node/ps.txt", "node/network_interface.json"}
+		for _, file := range files {
+			path := filepath.Join(r.DebugStore(), file)
+			f, err := os.Stat(path)
+			if err != nil {
+				t.Errorf("error stating %v: %v", path, err)
+			}
+			if f.Size() < 1 {
+				t.Errorf("file %v was empty", path)
+			}
 		}
 	})
 }


### PR DESCRIPTION
Signed-off-by: Taiki Ono <taiki@tetrate.io>

Fixes https://github.com/tetratelabs/getenvoy/issues/40

`Interfaces()` is just a wrapper of golang std's `Interfaces()` and it safely picks up interfaces. https://github.com/shirou/gopsutil/blob/v2.19.8/net/net.go#L212 And we can use JSON format to log interfaces at that time safely https://github.com/shirou/gopsutil/blob/v2.19.8/net/net.go#L193.

Output example:

```
[{"mtu":65536,"name":"lo","hardwareaddr":"","flags":["up","loopback"],"addrs":[{"addr":"127.0.0.1/8"},{"addr":"::1/128"}]},{"mtu":1500,"name":"eno1","hardwareaddr":"","flags":["up","broadcast","multicast"],"addrs":[{"addr":"192.168.11.7/24"},{"addr":""},{"addr":""},{"addr":""}]},{"mtu":1500,"name":"docker0","hardwareaddr":"","flags":["up","broadcast","multicast"],"addrs":[{"addr":"172.17.0.1/16"}]}]
```