### PR TITLE
Fix to output valid JSON string

### DIFF
--- a/pkg/binary/envoy/debug/node.go
+++ b/pkg/binary/envoy/debug/node.go
@@ -15,6 +15,7 @@
 package debug
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -132,7 +133,11 @@ func networkInterfaces(r binary.Runner) error {
 	if err != nil {
 		return fmt.Errorf("unable to fetch network Interfaces: %v", err)
 	}
-	fmt.Fprintln(f, is) // print with JSON format
+	out, err := json.Marshal(is)
+	if err != nil {
+		return fmt.Errorf("unable to convert to json representation: %v", err)
+	}
+	fmt.Fprintln(f, string(out))
 
 	return nil
 }

--- a/pkg/binary/envoy/debug/node_test.go
+++ b/pkg/binary/envoy/debug/node_test.go
@@ -15,8 +15,11 @@
 package debug
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,6 +43,19 @@ func Test_debugging_outputs(t *testing.T) {
 			}
 			if f.Size() < 1 {
 				t.Errorf("file %v was empty", path)
+			}
+			if strings.HasSuffix(file, ".json") {
+				raw, err := ioutil.ReadFile(path)
+				if err != nil {
+					t.Errorf("error to read the file %v: %v", path, err)
+				}
+				var is []interface{}
+				if err := json.Unmarshal(raw, &is); err != nil {
+					t.Errorf("error to unmarshal json string, %v: \"%v\"", err, raw)
+				}
+				if len(is) < 1 {
+					t.Errorf("unmarshaled content is empty, expected to be a non-empty array: \"%v\"", raw)
+				}
 			}
 		}
 	})


### PR DESCRIPTION
Previously, it writes invalid JSON string which lacks commas.

Signed-off-by: Taiki Ono <taiki@tetrate.io>

Follow-up of https://github.com/tetratelabs/getenvoy/pull/55.