### PR TITLE
Log all connections on the machine

### DIFF
--- a/pkg/binary/envoy/debug/node.go
+++ b/pkg/binary/envoy/debug/node.go
@@ -146,13 +146,13 @@ func networkInterfaces(r binary.Runner) error {
 
 type connStat struct {
 	Fd     uint32   `json:"fd"`
+	Pid    int32    `json:"pid"`
+	Uids   []int32  `json:"uids"`
 	Family string   `json:"family"`
 	Type   string   `json:"type"`
+	Status string   `json:"status"`
 	Laddr  net.Addr `json:"localaddr"`
 	Raddr  net.Addr `json:"remoteaddr"`
-	Status string   `json:"status"`
-	Uids   []int32  `json:"uids"`
-	Pid    int32    `json:"pid"`
 }
 
 var familyMap = map[uint32]string{
@@ -179,8 +179,8 @@ func activeConnections(r binary.Runner) error {
 	}
 
 	ret := make([]connStat, 0, len(cs))
-	for _, c := range cs {
-		st := addLabelToConnection(c)
+	for i := range cs {
+		st := addLabelToConnection(&cs[i])
 		ret = append(ret, st)
 	}
 	out, err := json.Marshal(ret)
@@ -193,7 +193,7 @@ func activeConnections(r binary.Runner) error {
 }
 
 // Replace uint32 label to human readable string label.
-func addLabelToConnection(orig net.ConnectionStat) connStat {
+func addLabelToConnection(orig *net.ConnectionStat) connStat {
 	family, ok := familyMap[orig.Family]
 	if !ok {
 		family = fmt.Sprintf("unknown(%v)", orig.Family)

--- a/pkg/binary/envoy/debug/node.go
+++ b/pkg/binary/envoy/debug/node.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"syscall"
 	"text/tabwriter"
 
 	"github.com/shirou/gopsutil/net"
@@ -37,6 +38,7 @@ func EnableNodeCollection(r *envoy.Runtime) {
 	}
 	r.RegisterPreTermination(ps)
 	r.RegisterPreTermination(networkInterfaces)
+	r.RegisterPreTermination(activeConnections)
 }
 
 func ps(r binary.Runner) error {
@@ -140,4 +142,74 @@ func networkInterfaces(r binary.Runner) error {
 	fmt.Fprintln(f, string(out))
 
 	return nil
+}
+
+type connStat struct {
+	Fd     uint32   `json:"fd"`
+	Family string   `json:"family"`
+	Type   string   `json:"type"`
+	Laddr  net.Addr `json:"localaddr"`
+	Raddr  net.Addr `json:"remoteaddr"`
+	Status string   `json:"status"`
+	Uids   []int32  `json:"uids"`
+	Pid    int32    `json:"pid"`
+}
+
+var familyMap = map[uint32]string{
+	syscall.AF_INET:  "AF_INET",
+	syscall.AF_INET6: "AF_INET6",
+	syscall.AF_UNIX:  "AF_UNIX",
+}
+
+var typeMap = map[uint32]string{
+	syscall.SOCK_STREAM: "SOCK_STREAM",
+	syscall.SOCK_DGRAM:  "SOCK_DGRAM",
+}
+
+func activeConnections(r binary.Runner) error {
+	f, err := os.Create(filepath.Join(r.DebugStore(), "node/connections.json"))
+	if err != nil {
+		return fmt.Errorf("unable to create file to write network interface output to: %v", err)
+	}
+	defer f.Close() //nolint
+
+	cs, _ := net.Connections("all")
+	if err != nil {
+		return fmt.Errorf("unable to fetch network Interfaces: %v", err)
+	}
+
+	var ret []connStat
+	for _, c := range cs {
+		st := addLabelToConnection(c)
+		ret = append(ret, st)
+	}
+	out, err := json.Marshal(ret)
+	if err != nil {
+		return fmt.Errorf("unable to convert to json representation: %v", err)
+	}
+	fmt.Fprintln(f, string(out))
+
+	return nil
+}
+
+// Replace uint32 label to human readable string label.
+func addLabelToConnection(orig net.ConnectionStat) connStat {
+	family, ok := familyMap[orig.Family]
+	if !ok {
+		family = fmt.Sprintf("unknown(%v)", orig.Family)
+	}
+	t, ok := typeMap[orig.Type]
+	if !ok {
+		t = fmt.Sprintf("unknown(%v)", orig.Type)
+	}
+	return connStat{
+		Fd:     orig.Fd,
+		Family: family,
+		Type:   t,
+		Laddr:  orig.Laddr,
+		Raddr:  orig.Raddr,
+		Status: orig.Status,
+		Uids:   orig.Uids,
+		Pid:    orig.Pid,
+	}
 }

--- a/pkg/binary/envoy/debug/node.go
+++ b/pkg/binary/envoy/debug/node.go
@@ -173,7 +173,7 @@ func activeConnections(r binary.Runner) error {
 	}
 	defer f.Close() //nolint
 
-	cs, _ := net.Connections("all")
+	cs, err := net.Connections("all")
 	if err != nil {
 		return fmt.Errorf("unable to fetch network Interfaces: %v", err)
 	}

--- a/pkg/binary/envoy/debug/node.go
+++ b/pkg/binary/envoy/debug/node.go
@@ -178,7 +178,7 @@ func activeConnections(r binary.Runner) error {
 		return fmt.Errorf("unable to fetch network Interfaces: %v", err)
 	}
 
-	var ret []connStat
+	ret := make([]connStat, 0, len(cs))
 	for _, c := range cs {
 		st := addLabelToConnection(c)
 		ret = append(ret, st)

--- a/pkg/binary/envoy/debug/node_test.go
+++ b/pkg/binary/envoy/debug/node_test.go
@@ -34,7 +34,7 @@ func Test_debugging_outputs(t *testing.T) {
 		defer os.RemoveAll(r.DebugStore())
 		envoytest.RunKill(r, filepath.Join("testdata", "null.yaml"), time.Second*10)
 
-		files := [...]string{"node/ps.txt", "node/network_interface.json"}
+		files := [...]string{"node/ps.txt", "node/network_interface.json", "node/connections.json"}
 		for _, file := range files {
 			path := filepath.Join(r.DebugStore(), file)
 			f, err := os.Stat(path)


### PR DESCRIPTION
On pre-termination.

Signed-off-by: Taiki Ono <taiki@tetrate.io>

https://github.com/tetratelabs/getenvoy/issues/38

Example:

```
[
  {
    "fd": 14,
    "family": "AF_INET",
    "type": "SOCK_STREAM",
    "localaddr": {
      "ip": "192.168.11.11",
      "port": 57219
    },
    "remoteaddr": {
      "ip": "192.168.11.9",
      "port": 55563
    },
    "status": "ESTABLISHED",
    "uids": null,
    "pid": 297
  }
]
```