### PR TITLE
handle successful envoy return codes

### DIFF
--- a/pkg/binary/envoy/termination.go
+++ b/pkg/binary/envoy/termination.go
@@ -23,6 +23,10 @@ import (
 
 func (r *Runtime) handleTermination() {
 	if r.cmd.ProcessState != nil {
+		if r.cmd.ProcessState.Success() {
+			log.Infof("Envoy process (PID=%d) exited successfully", r.cmd.Process.Pid)
+			return
+		}
 		log.Infof("Envoy process (PID=%d) terminated prematurely", r.cmd.Process.Pid)
 		return
 	}


### PR DESCRIPTION
```
go run cmd/getenvoy/main.go run standard:1.11.0 -- --version
2019-10-27T09:48:59.808199Z	error	Log collection is not supported on this Operating System
2019-10-27T09:48:59.808381Z	warn	Running on a non-Linux system, cannot set child process kill signal. Some cases where this process terminates before the Envoy child process may not be handled gracefully.
2019-10-27T09:48:59.808473Z	info	Envoy command: [/Users/liam/.getenvoy/builds/standard/1.11.0/darwin/bin/envoy --version]

/Users/liam/.getenvoy/builds/standard/1.11.0/darwin/bin/envoy  version: bf169f9d3c8f4c682650c5390c088a4898940913/1.11.0/clean-getenvoy-af8a2e7/RELEASE/BoringSSL

2019-10-27T09:48:59.876601Z	info	No Envoy processes remaining, terminating GetEnvoy process (PID=44414)
2019-10-27T09:48:59.876634Z	info	Envoy process (PID=44415) exited successfully
```

Signed-off-by: Liam White <liam@tetrate.io>