### PR TITLE
Add user-agent on requesting external url

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,7 @@ before:
     - go mod download
 builds:
 - binary: getenvoy
-  ldflags: "-s -w -X github.com/tetratelabs/getenvoy/pkg/version.Version={{.Version}}"
+  ldflags: "-s -w -X github.com/tetratelabs/getenvoy/pkg/version.version={{.Version}}"
   main: ./cmd/getenvoy/main.go
   env:
   - CGO_ENABLED=0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,7 +20,7 @@ before:
     - go mod download
 builds:
 - binary: getenvoy
-  ldflags: "-s -w -X github.com/tetratelabs/getenvoy/pkg/cmd.cliVersion={{.Version}}"
+  ldflags: "-s -w -X github.com/tetratelabs/getenvoy/pkg/version.Version={{.Version}}"
   main: ./cmd/getenvoy/main.go
   env:
   - CGO_ENABLED=0

--- a/pkg/binary/envoy/fetch.go
+++ b/pkg/binary/envoy/fetch.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mholt/archiver"
 	"github.com/schollz/progressbar/v2"
 	"github.com/tetratelabs/getenvoy/pkg/manifest"
+	"github.com/tetratelabs/getenvoy/pkg/transport"
 	"github.com/tetratelabs/log"
 )
 
@@ -91,7 +92,7 @@ func fetchEnvoy(dst, src string) error {
 
 func doDownload(dst, src string) (string, error) {
 	// #nosec -> src destination can be anywhere by design
-	resp, err := http.Get(src)
+	resp, err := transport.Get(src)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tetratelabs/getenvoy/pkg/version"
 )
 
-// NewRoot create a new root command and sets the cliVersion to the passed variable
+// NewRoot create a new root command and sets the version to the passed variable
 // TODO: Add version support on the command
 func NewRoot() *cobra.Command {
 	rootCmd.AddCommand(NewRunCmd())
@@ -40,7 +40,7 @@ var (
 		Short:             "Fetch, deploy and debug Envoy",
 		Long: `Manage full lifecycle of Envoy including fetching binaries,
 bootstrap generation and automated collection of access logs, Envoy state and machine state.`,
-		Version: version.Version,
+		Version: version.Build.Version,
 	}
 
 	manifestURL string

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -17,10 +17,8 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/tetratelabs/getenvoy/pkg/manifest"
+	"github.com/tetratelabs/getenvoy/pkg/version"
 )
-
-// cliVersion exposed by goreleaser
-var cliVersion string
 
 // NewRoot create a new root command and sets the cliVersion to the passed variable
 // TODO: Add version support on the command
@@ -42,7 +40,7 @@ var (
 		Short:             "Fetch, deploy and debug Envoy",
 		Long: `Manage full lifecycle of Envoy including fetching binaries,
 bootstrap generation and automated collection of access logs, Envoy state and machine state.`,
-		Version: cliVersion,
+		Version: version.Version,
 	}
 
 	manifestURL string

--- a/pkg/manifest/print.go
+++ b/pkg/manifest/print.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"text/tabwriter"
 
+	"github.com/tetratelabs/getenvoy/pkg/transport"
+
 	"net/url"
 
 	"strings"
@@ -61,7 +63,7 @@ func platformFromEnum(s string) string {
 
 func fetch(manifestURL string) (*api.Manifest, error) {
 	// #nosec => This is by design, users can call out to wherever they like!
-	resp, err := http.Get(manifestURL)
+	resp, err := transport.Get(manifestURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/transport/client.go
+++ b/pkg/transport/client.go
@@ -26,7 +26,7 @@ var (
 	defaultClient = NewClient(AddUserAgent(cliUserAgent))
 )
 
-// Options represents an argument of NewClient
+// Option represents an argument of NewClient
 type Option func(http.RoundTripper) http.RoundTripper
 
 // NewClient returns HTTP client for use of GetEnvoy CLI.

--- a/pkg/transport/client.go
+++ b/pkg/transport/client.go
@@ -1,0 +1,62 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/tetratelabs/getenvoy/pkg/version"
+)
+
+var (
+	CliUserAgent  = fmt.Sprintf("GetEnvoy/%s", version.Version)
+	DefaultClient = NewClient(AddUserAgent(CliUserAgent))
+)
+
+type Option func(http.RoundTripper) http.RoundTripper
+
+// NewClient returns HTTP client for use of GetEnvoy CLI.
+// User-Agent "GetEnvoy/{Version}" will be added to the client.
+func NewClient(opts ...Option) *http.Client {
+	tr := http.DefaultTransport
+	for _, opt := range opts {
+		tr = opt(tr)
+	}
+	client := &http.Client{Transport: tr}
+	return client
+}
+
+func AddUserAgent(ua string) Option {
+	return func(tr http.RoundTripper) http.RoundTripper {
+		return &funcTripper{roundTrip: func(r *http.Request) (*http.Response, error) {
+			r.Header.Add("User-Agent", ua)
+			return tr.RoundTrip(r)
+		}}
+	}
+}
+
+type funcTripper struct {
+	roundTrip func(*http.Request) (*http.Response, error)
+}
+
+func (f funcTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f.roundTrip(r)
+}
+
+// Get is thin wrapper of net/http.Get.
+func Get(url string) (*http.Response, error) {
+	return DefaultClient.Get(url)
+}

--- a/pkg/transport/client.go
+++ b/pkg/transport/client.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	cliUserAgent  = fmt.Sprintf("GetEnvoy/%s", version.Version)
+	cliUserAgent  = fmt.Sprintf("GetEnvoy/%s", version.Build.Version)
 	defaultClient = NewClient(AddUserAgent(cliUserAgent))
 )
 

--- a/pkg/transport/client.go
+++ b/pkg/transport/client.go
@@ -22,14 +22,14 @@ import (
 )
 
 var (
-	CliUserAgent  = fmt.Sprintf("GetEnvoy/%s", version.Version)
-	DefaultClient = NewClient(AddUserAgent(CliUserAgent))
+	cliUserAgent  = fmt.Sprintf("GetEnvoy/%s", version.Version)
+	defaultClient = NewClient(AddUserAgent(cliUserAgent))
 )
 
+// Options represents an argument of NewClient
 type Option func(http.RoundTripper) http.RoundTripper
 
 // NewClient returns HTTP client for use of GetEnvoy CLI.
-// User-Agent "GetEnvoy/{Version}" will be added to the client.
 func NewClient(opts ...Option) *http.Client {
 	tr := http.DefaultTransport
 	for _, opt := range opts {
@@ -39,6 +39,8 @@ func NewClient(opts ...Option) *http.Client {
 	return client
 }
 
+// AddUserAgent returns Option that adds passed user-agent to every requests.
+// It should be passed as an argument of NewClient.
 func AddUserAgent(ua string) Option {
 	return func(tr http.RoundTripper) http.RoundTripper {
 		return &funcTripper{roundTrip: func(r *http.Request) (*http.Response, error) {
@@ -58,5 +60,5 @@ func (f funcTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 
 // Get is thin wrapper of net/http.Get.
 func Get(url string) (*http.Response, error) {
-	return DefaultClient.Get(url)
+	return defaultClient.Get(url)
 }

--- a/pkg/transport/client_test.go
+++ b/pkg/transport/client_test.go
@@ -1,0 +1,55 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestClientWithoutRequest(t *testing.T) {
+	ua := fmt.Sprintf("GetEnvoy/%s", "1.0")
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := http.Header{
+			"Accept-Encoding": []string{"gzip"},
+			"User-Agent":      []string{ua},
+		}
+		if !reflect.DeepEqual(r.Header, want) {
+			t.Errorf("Request.Header = %#v; want %#v", r.Header, want)
+		}
+		if t.Failed() {
+			w.Header().Set("Result", "got errors")
+		} else {
+			w.Header().Set("Result", "ok")
+		}
+	}))
+	defer ts.Close()
+
+	client := NewClient(AddUserAgent(ua))
+	res, err := client.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		t.Fatal(res.Status)
+	}
+	if got := res.Header.Get("Result"); got != "ok" {
+		t.Errorf("result = %q; want ok", got)
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+var Version string

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package version
 
 // Version is populated at build time

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,4 @@
 package version
 
+// Version is populated at build time
 var Version string

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,5 +14,19 @@
 
 package version
 
-// Version is populated at build time
-var Version string
+var (
+	// version is populated at build time via compiler options.
+	version string
+)
+
+// BuildInfo describes a particular build of getenvoy toolkit.
+type BuildInfo struct {
+	Version string
+}
+
+var (
+	// Build describes a version of the enclosing binary.
+	Build = BuildInfo{
+		Version: version,
+	}
+)


### PR DESCRIPTION
This patch will add user-agent on requesting external endpoint such as fetching envoy binary or manifest. This enables us to know which version users use and make it easier to support GetEnvoy users.

The format of user-agent is `GetEnvoy/{Version}`.

Signed-off-by: Kotaro Inoue k.musaino@gmail.com