### PR TITLE
Add postgres experience

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	bitbucket.org/creachadair/shell v0.0.6
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
+	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48
 	github.com/golang/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878 h1:EFSB7Zo9Eg91v7MJPVsifUysc/wPdN+NOnVe6bWbdBM=
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQhVx52RsWOnlkpikZr01T/yAVN2gn0861vByNg=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.13.24/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/binary/envoy/config.go
+++ b/pkg/binary/envoy/config.go
@@ -74,25 +74,22 @@ type Config struct {
 	StatNameLength int32
 }
 
-func (r *Runtime) SaveConfig(name string, config string) (error, string) {
+func (r *Runtime) SaveConfig(name string, config string) (string, error) {
 	configDir := filepath.Join(r.RootDir, "configs")
-		if err := os.MkdirAll(configDir, 0750); err != nil {
-			return fmt.Errorf("unable to create directory %q: %v", configDir, err), ""
-		}
+	if err := os.MkdirAll(configDir, 0750); err != nil {
+		return "", fmt.Errorf("unable to create directory %q: %v", configDir, err)
+	}
 
-  f, err := os.OpenFile(filepath.Join(configDir, name + ".yaml"), os.O_RDWR|os.O_CREATE, 0660)
-  if err != nil {
-	  return fmt.Errorf("Cannot create config directory %s: %s", configDir, err), ""
-  }
-	 
-  defer f.Close()
+	f, err := os.OpenFile(filepath.Join(configDir, name+".yaml"), os.O_RDWR|os.O_CREATE, 0660)
+	if err != nil {
+		return "", fmt.Errorf("Cannot create config directory %s: %s", configDir, err)
+	}
 
-  if _, err = f.WriteString(config); err != nil {
-	  return fmt.Errorf("Cannot save config file %s: %s", filepath.Join(configDir, name + ".yaml"), err), ""
-  }
+	defer f.Close()
 
-	// r.AppendArgs("--config-path ")
-	//r.AppendArgs([]string{"--config-path ", filepath.Join(configDir, name + ".yaml")})
-		
-  return nil, filepath.Join(configDir, name + ".yaml")
+	if _, err = f.WriteString(config); err != nil {
+		return "", fmt.Errorf("Cannot save config file %s: %s", filepath.Join(configDir, name+".yaml"), err)
+	}
+
+	return filepath.Join(configDir, name+".yaml"), nil
 }

--- a/pkg/binary/envoy/config.go
+++ b/pkg/binary/envoy/config.go
@@ -16,6 +16,7 @@ package envoy
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -82,17 +83,9 @@ func (r *Runtime) SaveConfig(name, config string) (string, error) {
 		return "", fmt.Errorf("Unable to create directory %q: %v", configDir, err)
 	}
 	filename := name + ".yaml"
-
-	f, err := os.OpenFile(filepath.Join(configDir, filename), os.O_RDWR|os.O_CREATE, 0600)
+	err := ioutil.WriteFile(filepath.Join(configDir, filename), []byte(config), 0644)
 	if err != nil {
-		return "", fmt.Errorf("Cannot create config file %s: %s", configDir, err)
-	}
-
-	defer f.Close() //nolint
-
-	if _, err = f.WriteString(config); err != nil {
 		return "", fmt.Errorf("Cannot save config file %s: %s", filepath.Join(configDir, filename), err)
 	}
-
 	return filepath.Join(configDir, filename), nil
 }

--- a/pkg/binary/envoy/config.go
+++ b/pkg/binary/envoy/config.go
@@ -15,6 +15,9 @@
 package envoy
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/gogo/protobuf/types"
@@ -69,4 +72,27 @@ type Config struct {
 	ConnectTimeout *types.Duration
 	AdminPort      int32
 	StatNameLength int32
+}
+
+func (r *Runtime) SaveConfig(name string, config string) (error, string) {
+	configDir := filepath.Join(r.RootDir, "configs")
+		if err := os.MkdirAll(configDir, 0750); err != nil {
+			return fmt.Errorf("unable to create directory %q: %v", configDir, err), ""
+		}
+
+  f, err := os.OpenFile(filepath.Join(configDir, name + ".yaml"), os.O_RDWR|os.O_CREATE, 0660)
+  if err != nil {
+	  return fmt.Errorf("Cannot create config directory %s: %s", configDir, err), ""
+  }
+	 
+  defer f.Close()
+
+  if _, err = f.WriteString(config); err != nil {
+	  return fmt.Errorf("Cannot save config file %s: %s", filepath.Join(configDir, name + ".yaml"), err), ""
+  }
+
+	// r.AppendArgs("--config-path ")
+	//r.AppendArgs([]string{"--config-path ", filepath.Join(configDir, name + ".yaml")})
+		
+  return nil, filepath.Join(configDir, name + ".yaml")
 }

--- a/pkg/binary/envoy/config.go
+++ b/pkg/binary/envoy/config.go
@@ -74,22 +74,25 @@ type Config struct {
 	StatNameLength int32
 }
 
-func (r *Runtime) SaveConfig(name string, config string) (string, error) {
+// SaveConfig saves configuration string in getenvoy
+// directory.
+func (r *Runtime) SaveConfig(name, config string) (string, error) {
 	configDir := filepath.Join(r.RootDir, "configs")
 	if err := os.MkdirAll(configDir, 0750); err != nil {
-		return "", fmt.Errorf("unable to create directory %q: %v", configDir, err)
+		return "", fmt.Errorf("Unable to create directory %q: %v", configDir, err)
 	}
+	filename := name + ".yaml"
 
-	f, err := os.OpenFile(filepath.Join(configDir, name+".yaml"), os.O_RDWR|os.O_CREATE, 0660)
+	f, err := os.OpenFile(filepath.Join(configDir, filename), os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
-		return "", fmt.Errorf("Cannot create config directory %s: %s", configDir, err)
+		return "", fmt.Errorf("Cannot create config file %s: %s", configDir, err)
 	}
 
-	defer f.Close()
+	defer f.Close() //nolint
 
 	if _, err = f.WriteString(config); err != nil {
-		return "", fmt.Errorf("Cannot save config file %s: %s", filepath.Join(configDir, name+".yaml"), err)
+		return "", fmt.Errorf("Cannot save config file %s: %s", filepath.Join(configDir, filename), err)
 	}
 
-	return filepath.Join(configDir, name+".yaml"), nil
+	return filepath.Join(configDir, filename), nil
 }

--- a/pkg/binary/envoy/runtime.go
+++ b/pkg/binary/envoy/runtime.go
@@ -34,7 +34,7 @@ func NewRuntime(options ...func(*Runtime)) (binary.FetchRunner, error) {
 	local := filepath.Join(usrDir, ".getenvoy")
 	runtime := &Runtime{
 		Config:         NewConfig(),
-		RootDir:	local,
+		RootDir:        local,
 		fetcher:        fetcher{local},
 		TmplDir:        filepath.Join(local, "templates"),
 		wg:             &sync.WaitGroup{},

--- a/pkg/binary/envoy/runtime.go
+++ b/pkg/binary/envoy/runtime.go
@@ -34,6 +34,7 @@ func NewRuntime(options ...func(*Runtime)) (binary.FetchRunner, error) {
 	local := filepath.Join(usrDir, ".getenvoy")
 	runtime := &Runtime{
 		Config:         NewConfig(),
+		RootDir:	local,
 		fetcher:        fetcher{local},
 		TmplDir:        filepath.Join(local, "templates"),
 		wg:             &sync.WaitGroup{},
@@ -60,6 +61,7 @@ type fetcher struct {
 type Runtime struct {
 	fetcher
 
+	RootDir  string
 	debugDir string
 	TmplDir  string
 	Config   *Config

--- a/pkg/binary/interface.go
+++ b/pkg/binary/interface.go
@@ -39,6 +39,9 @@ type Runner interface {
 	DebugStore() string
 	SetStdout(w io.Writer)
 	SetStderr(w io.Writer)
+	// TODO(cpakulski) Maybe Runner is not the best place for SaveConfig.
+	// It was added here because it needs location of .getenvoy
+	// directory.
 	SaveConfig(name string, config string) (string, error)
 }
 

--- a/pkg/binary/interface.go
+++ b/pkg/binary/interface.go
@@ -39,7 +39,7 @@ type Runner interface {
 	DebugStore() string
 	SetStdout(w io.Writer)
 	SetStderr(w io.Writer)
-	SaveConfig(name string, config string) (error, string)
+	SaveConfig(name string, config string) (string, error)
 }
 
 const (

--- a/pkg/binary/interface.go
+++ b/pkg/binary/interface.go
@@ -39,6 +39,7 @@ type Runner interface {
 	DebugStore() string
 	SetStdout(w io.Writer)
 	SetStderr(w io.Writer)
+	SaveConfig(name string, config string) (error, string)
 }
 
 const (

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -58,7 +58,7 @@ getenvoy run ./envoy -- --config-path ./bootstrap.yaml
 getenvoy run standard:1.11.1 -- --help
 
 # Run with Postgres specific configuration bootstrapped
-getenvoy run postgres:nightly --templateArg Endpoint=127.0.0.0 --templateArg InPort=1114
+getenvoy run postgres:nightly --templateArg endpoint=127.0.0.1:5432 --templateArg inport=5555
 `,
 		Args: func(cmd *cobra.Command, args []string) error {
 			return validateCmdArgs(args)
@@ -125,7 +125,7 @@ getenvoy run postgres:nightly --templateArg Endpoint=127.0.0.0 --templateArg InP
 		"(experimental) location of Envoy's access log server <host|ip:port> (requires bootstrap flag)")
 	cmd.Flags().StringVar(&mode, "mode", "",
 		fmt.Sprintf("(experimental) mode to run Envoy in <%v> (requires bootstrap flag)", strings.Join(envoy.SupportedModes, "|")))
-	cmd.Flags().StringToStringVarP(&templateArgs, "templateArg", "", map[string]string{},
+	cmd.Flags().StringToStringVar(&templateArgs, "templateArg", map[string]string{},
 		"arguments passed to a config template for substitution")
 	return cmd
 }

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -58,7 +58,7 @@ getenvoy run ./envoy -- --config-path ./bootstrap.yaml
 getenvoy run standard:1.11.1 -- --help
 
 # Run with Postgres specific configuration bootstrapped
-getenvoy run postgres:nightly --templateArg endpoint=127.0.0.1:5432 --templateArg inport=5555
+getenvoy run postgres:nightly --templateArg endpoints=127.0.0.1:5432,192.168.0.101:5432 --templateArg inport=5555
 `,
 		Args: func(cmd *cobra.Command, args []string) error {
 			return validateCmdArgs(args)

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -108,12 +108,12 @@ getenvoy run standard:1.11.1 -- --help
 						return fmt.Errorf("--templateArg and %s cannot be specified at the same time", envoyParam)
 					}
 				}
-				err, config := flavor.CreateConfig(key.Flavor, templateParams)
+				config, err := flavors.CreateConfig(key.Flavor, templateParams)
 				if err != nil {
 					return err
 				}
 				// Save config in getenvoy directory
-				err, path := runtime.SaveConfig(key.Flavor, config)
+				path, err := runtime.SaveConfig(key.Flavor, config)
 				if err != nil {
 					return err
 				}

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -87,6 +87,13 @@ getenvoy run postgres:nightly --templateArg Endpoint=127.0.0.0 --templateArg InP
 
 			key, manifestErr := manifest.NewKey(args[0])
 
+			if manifestErr != nil {
+				if _, err := os.Stat(args[0]); err != nil {
+					return fmt.Errorf("%v isn't valid manifest reference or an existing filepath", args[0])
+				}
+				return runtime.RunPath(args[0], args[1:])
+			}
+
 			// Check if the templateArgs were passed to the cmd line.
 			// If they were passed, config must be created based on
 			// template.
@@ -98,12 +105,6 @@ getenvoy run postgres:nightly --templateArg Endpoint=127.0.0.0 --templateArg InP
 				args = append(args, cmdArg)
 			}
 
-			if manifestErr != nil {
-				if _, err := os.Stat(args[0]); err != nil {
-					return fmt.Errorf("%v isn't valid manifest reference or an existing filepath", args[0])
-				}
-				return runtime.RunPath(args[0], args[1:])
-			}
 			if !runtime.AlreadyDownloaded(key) {
 				location, err := manifest.Locate(key, manifestURL)
 				if err != nil {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -26,7 +26,7 @@ import (
 	"github.com/tetratelabs/getenvoy/pkg/binary/envoy/controlplane"
 	"github.com/tetratelabs/getenvoy/pkg/binary/envoy/debug"
 	"github.com/tetratelabs/getenvoy/pkg/flavors"
-	_ "github.com/tetratelabs/getenvoy/pkg/flavors/postgres"
+	_ "github.com/tetratelabs/getenvoy/pkg/flavors/postgres" //nolint 
 	"github.com/tetratelabs/getenvoy/pkg/manifest"
 )
 

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -98,7 +98,7 @@ getenvoy run postgres:nightly --templateArg endpoints=127.0.0.1:5432,192.168.0.1
 			// If they were passed, config must be created based on
 			// template.
 			if len(templateArgs) > 0 {
-				cmdArg, err := processTemplateArgs(key.Flavor, args, templateArgs, runtime.(*envoy.Runtime))
+				cmdArg, err := processTemplateArgs(key.Flavor, templateArgs, runtime.(*envoy.Runtime))
 				if err != nil {
 					return err
 				}
@@ -189,15 +189,9 @@ func controlplaneFunc() func(r *envoy.Runtime) {
 	}
 }
 
-// Function verifies template parameters passed in getenvoy command line.
-// If verification is successful, it returns a string which must be added to
-// Envoy command line to invoke a proper config.
-func processTemplateArgs(flavor string, args []string, templateArgs map[string]string, runtime *envoy.Runtime) (string, error) {
-	for _, envoyParam := range args {
-		if strings.HasPrefix(envoyParam, "--config") {
-			return "", fmt.Errorf("--templateArg and %s cannot be specified at the same time", envoyParam)
-		}
-	}
+// Function creates config file based on template args passed by a user.
+// The return value is Envoy command line option which must be passed to Envoy.
+func processTemplateArgs(flavor string, templateArgs map[string]string, runtime *envoy.Runtime) (string, error) {
 	config, err := flavors.CreateConfig(flavor, templateArgs)
 	if err != nil {
 		return "", err

--- a/pkg/flavors/flavors.go
+++ b/pkg/flavors/flavors.go
@@ -22,28 +22,28 @@ import (
 
 // FlavorConfigTemplate - interface to individual flavors.
 type FlavorConfigTemplate interface {
-	CheckParams(params map[string]string) (interface{}, error)
+	CheckParseParams(params map[string]string) error
 	GetTemplate() string
 }
 
 // Main repo for templates.
-type templateStore struct {
+type flavorStore struct {
 	// This is a map indexed by flavor pointing to the individual
 	// implementaions of each flavor.
 	templates map[string]FlavorConfigTemplate
 }
 
-var store = templateStore{templates: make(map[string]FlavorConfigTemplate)}
+var store = flavorStore{templates: make(map[string]FlavorConfigTemplate)}
 
-// AddTemplate - function is used by individual flavors (like postgres)
+// AddFlavor - function is used by individual flavors (like postgres)
 // to add the flavor to main repo.
-func AddTemplate(flavor string, configTemplate FlavorConfigTemplate) {
+func AddFlavor(flavor string, configTemplate FlavorConfigTemplate) {
 	store.templates[flavor] = configTemplate
 }
 
-// GetTemplate - function returns FlavorConfigTemplate structure associated
+// GetFlavor - function returns FlavorConfigTemplate structure associated
 // with flavor.
-func GetTemplate(flavor string) (FlavorConfigTemplate, error) {
+func GetFlavor(flavor string) (FlavorConfigTemplate, error) {
 	tmplString, ok := store.templates[flavor]
 	if !ok {
 		return nil, fmt.Errorf("Cannot find template for flavor %s", flavor)
@@ -55,13 +55,13 @@ func GetTemplate(flavor string) (FlavorConfigTemplate, error) {
 // CreateConfig - function checks flavor specific parameters, get flavor's template and
 // create a config.
 func CreateConfig(flavor string, params map[string]string) (string, error) {
-	flavorData, err := GetTemplate(flavor)
+	flavorData, err := GetFlavor(flavor)
 
 	if err != nil {
 		return "", err
 	}
 
-	data, err := flavorData.CheckParams(params)
+	err = flavorData.CheckParseParams(params)
 	if err != nil {
 		return "", err
 	}
@@ -75,6 +75,6 @@ func CreateConfig(flavor string, params map[string]string) (string, error) {
 		return "", fmt.Errorf("Supplied template for flavor %s is incorrect", flavor)
 	}
 	var buf bytes.Buffer
-	tmpl.Execute(&buf, data) //nolint
+	tmpl.Execute(&buf, flavorData) //nolint
 	return buf.String(), nil
 }

--- a/pkg/flavors/flavors.go
+++ b/pkg/flavors/flavors.go
@@ -1,0 +1,47 @@
+package flavor
+
+import (
+	"fmt"
+)
+
+// Interface to individual flavors.
+type FlavorConfigTemplate interface {
+  CreateConfig(params map[string]string) (error, string)
+}
+
+
+// Main repo for templates.
+
+type TemplateStore struct {
+  // This is a map indexed by flavor pointing to the individual 
+  // implementaions of each flavor.
+  templates map[string]FlavorConfigTemplate
+}
+
+var store TemplateStore = TemplateStore{templates: make(map[string]FlavorConfigTemplate)}
+
+//func New(path string) *TemplateStore {
+//	return &TemplateStore{path: path};
+//}
+
+func (store *TemplateStore) GetTemplate(flavor string) (error, FlavorConfigTemplate) {
+  template, ok := store.templates[flavor]
+  if !ok {
+	  return fmt.Errorf("Cannot find template for flavor %s", flavor), nil
+  }
+
+  return nil, template
+}
+
+func AddTemplate(flavor string,  configTemplate FlavorConfigTemplate) {
+  store.templates[flavor] = configTemplate
+}
+
+func GetTemplate(flavor string) (error, FlavorConfigTemplate) {
+  template, ok := store.templates[flavor]
+  if !ok {
+	  return fmt.Errorf("Cannot find template for flavor %s", flavor), nil
+  }
+
+  return nil, template
+}

--- a/pkg/flavors/flavors.go
+++ b/pkg/flavors/flavors.go
@@ -15,15 +15,12 @@
 package flavors
 
 import (
-	"bytes"
 	"fmt"
-	"text/template"
 )
 
 // FlavorConfigTemplate - interface to individual flavors.
 type FlavorConfigTemplate interface {
-	CheckParseParams(params map[string]string) error
-	GetTemplate() string
+	GenerateConfig(params map[string]string) (string, error)
 }
 
 // Main repo for templates.
@@ -61,20 +58,5 @@ func CreateConfig(flavor string, params map[string]string) (string, error) {
 		return "", err
 	}
 
-	err = flavorData.CheckParseParams(params)
-	if err != nil {
-		return "", err
-	}
-
-	// NOw run the template substitution
-	tmpl := template.New(flavor)
-	tmpl, err = tmpl.Parse(flavorData.GetTemplate())
-	if err != nil {
-		// Template is not supplied by a user, but is compiled-in, so this error should
-		// happen only during development time.
-		return "", fmt.Errorf("Supplied template for flavor %s is incorrect", flavor)
-	}
-	var buf bytes.Buffer
-	tmpl.Execute(&buf, flavorData) //nolint
-	return buf.String(), nil
+	return flavorData.GenerateConfig(params)
 }

--- a/pkg/flavors/flavors.go
+++ b/pkg/flavors/flavors.go
@@ -1,12 +1,16 @@
 package flavor
 
 import (
+	"bytes"
 	"fmt"
+	"text/template"
 )
 
 // Interface to individual flavors.
 type FlavorConfigTemplate interface {
   CreateConfig(params map[string]string) (error, string)
+  CheckParams(params map[string]string) (error, interface{})
+  GetTemplate() string
 }
 
 
@@ -45,3 +49,31 @@ func GetTemplate(flavor string) (error, FlavorConfigTemplate) {
 
   return nil, template
 }
+
+// Function checks flavor specific paramaters, get flavor's template and
+// create a config.
+func CreateConfig(flavor string, params map[string]string) (error, string) {
+  err, flavorData := GetTemplate(flavor)
+
+  if err != nil {
+	  return err, ""
+  }
+
+  err, data := flavorData.CheckParams(params)
+  if err != nil  {
+	return err, ""
+  }
+
+  // NOw run the template substitution
+  tmpl := template.New(flavor)
+  tmpl, err = tmpl.Parse(flavorData.GetTemplate())
+  if err != nil {
+    // Template is not supplied by a user, but is compiled-in, so this error should
+    // happen only during development time.
+    return fmt.Errorf("Supplied template for flavor %s is incorrect.", flavor), ""
+  }
+  var buf bytes.Buffer
+  tmpl.Execute(&buf, data)
+  return nil, buf.String()
+}
+

--- a/pkg/flavors/flavors.go
+++ b/pkg/flavors/flavors.go
@@ -22,7 +22,6 @@ import (
 
 // FlavorConfigTemplate - interface to individual flavors.
 type FlavorConfigTemplate interface {
-	//CreateConfig(params map[string]string) (error, string)
 	CheckParams(params map[string]string) (interface{}, error)
 	GetTemplate() string
 }
@@ -36,7 +35,7 @@ type templateStore struct {
 
 var store = templateStore{templates: make(map[string]FlavorConfigTemplate)}
 
-// AddTemplate - function is used by individual flavours (like postgres)
+// AddTemplate - function is used by individual flavors (like postgres)
 // to add the flavor to main repo.
 func AddTemplate(flavor string, configTemplate FlavorConfigTemplate) {
 	store.templates[flavor] = configTemplate
@@ -45,15 +44,15 @@ func AddTemplate(flavor string, configTemplate FlavorConfigTemplate) {
 // GetTemplate - function returns FlavorConfigTemplate structure associated
 // with flavor.
 func GetTemplate(flavor string) (FlavorConfigTemplate, error) {
-	template, ok := store.templates[flavor]
+	tmplString, ok := store.templates[flavor]
 	if !ok {
 		return nil, fmt.Errorf("Cannot find template for flavor %s", flavor)
 	}
 
-	return template, nil
+	return tmplString, nil
 }
 
-// CreateConfig - function checks flavor specific paramaters, get flavor's template and
+// CreateConfig - function checks flavor specific parameters, get flavor's template and
 // create a config.
 func CreateConfig(flavor string, params map[string]string) (string, error) {
 	flavorData, err := GetTemplate(flavor)
@@ -73,9 +72,9 @@ func CreateConfig(flavor string, params map[string]string) (string, error) {
 	if err != nil {
 		// Template is not supplied by a user, but is compiled-in, so this error should
 		// happen only during development time.
-		return "", fmt.Errorf("Supplied template for flavor %s is incorrect.", flavor)
+		return "", fmt.Errorf("Supplied template for flavor %s is incorrect", flavor)
 	}
 	var buf bytes.Buffer
-	tmpl.Execute(&buf, data)
+	tmpl.Execute(&buf, data) //nolint
 	return buf.String(), nil
 }

--- a/pkg/flavors/flavors.go
+++ b/pkg/flavors/flavors.go
@@ -1,3 +1,16 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package flavor
 
 import (
@@ -8,72 +21,56 @@ import (
 
 // Interface to individual flavors.
 type FlavorConfigTemplate interface {
-  CreateConfig(params map[string]string) (error, string)
-  CheckParams(params map[string]string) (error, interface{})
-  GetTemplate() string
+	//CreateConfig(params map[string]string) (error, string)
+	CheckParams(params map[string]string) (error, interface{})
+	GetTemplate() string
 }
 
-
 // Main repo for templates.
-
 type TemplateStore struct {
-  // This is a map indexed by flavor pointing to the individual 
-  // implementaions of each flavor.
-  templates map[string]FlavorConfigTemplate
+	// This is a map indexed by flavor pointing to the individual
+	// implementaions of each flavor.
+	templates map[string]FlavorConfigTemplate
 }
 
 var store TemplateStore = TemplateStore{templates: make(map[string]FlavorConfigTemplate)}
 
-//func New(path string) *TemplateStore {
-//	return &TemplateStore{path: path};
-//}
-
-func (store *TemplateStore) GetTemplate(flavor string) (error, FlavorConfigTemplate) {
-  template, ok := store.templates[flavor]
-  if !ok {
-	  return fmt.Errorf("Cannot find template for flavor %s", flavor), nil
-  }
-
-  return nil, template
-}
-
-func AddTemplate(flavor string,  configTemplate FlavorConfigTemplate) {
-  store.templates[flavor] = configTemplate
+func AddTemplate(flavor string, configTemplate FlavorConfigTemplate) {
+	store.templates[flavor] = configTemplate
 }
 
 func GetTemplate(flavor string) (error, FlavorConfigTemplate) {
-  template, ok := store.templates[flavor]
-  if !ok {
-	  return fmt.Errorf("Cannot find template for flavor %s", flavor), nil
-  }
+	template, ok := store.templates[flavor]
+	if !ok {
+		return fmt.Errorf("Cannot find template for flavor %s", flavor), nil
+	}
 
-  return nil, template
+	return nil, template
 }
 
 // Function checks flavor specific paramaters, get flavor's template and
 // create a config.
 func CreateConfig(flavor string, params map[string]string) (error, string) {
-  err, flavorData := GetTemplate(flavor)
+	err, flavorData := GetTemplate(flavor)
 
-  if err != nil {
-	  return err, ""
-  }
+	if err != nil {
+		return err, ""
+	}
 
-  err, data := flavorData.CheckParams(params)
-  if err != nil  {
-	return err, ""
-  }
+	err, data := flavorData.CheckParams(params)
+	if err != nil {
+		return err, ""
+	}
 
-  // NOw run the template substitution
-  tmpl := template.New(flavor)
-  tmpl, err = tmpl.Parse(flavorData.GetTemplate())
-  if err != nil {
-    // Template is not supplied by a user, but is compiled-in, so this error should
-    // happen only during development time.
-    return fmt.Errorf("Supplied template for flavor %s is incorrect.", flavor), ""
-  }
-  var buf bytes.Buffer
-  tmpl.Execute(&buf, data)
-  return nil, buf.String()
+	// NOw run the template substitution
+	tmpl := template.New(flavor)
+	tmpl, err = tmpl.Parse(flavorData.GetTemplate())
+	if err != nil {
+		// Template is not supplied by a user, but is compiled-in, so this error should
+		// happen only during development time.
+		return fmt.Errorf("Supplied template for flavor %s is incorrect.", flavor), ""
+	}
+	var buf bytes.Buffer
+	tmpl.Execute(&buf, data)
+	return nil, buf.String()
 }
-

--- a/pkg/flavors/flavors.go
+++ b/pkg/flavors/flavors.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 )
 
-// FlavorConfigTemplate - interface to individual flavors.
+// FlavorConfigTemplate represents interface to individual flavors.
 type FlavorConfigTemplate interface {
 	GenerateConfig(params map[string]string) (string, error)
 }
@@ -32,13 +32,13 @@ type flavorStore struct {
 
 var store = flavorStore{templates: make(map[string]FlavorConfigTemplate)}
 
-// AddFlavor - function is used by individual flavors (like postgres)
+// AddFlavor function is used by individual flavors (like postgres)
 // to add the flavor to main repo.
 func AddFlavor(flavor string, configTemplate FlavorConfigTemplate) {
 	store.templates[flavor] = configTemplate
 }
 
-// GetFlavor - function returns FlavorConfigTemplate structure associated
+// GetFlavor function returns FlavorConfigTemplate structure associated
 // with flavor.
 func GetFlavor(flavor string) (FlavorConfigTemplate, error) {
 	tmplString, ok := store.templates[flavor]
@@ -49,7 +49,7 @@ func GetFlavor(flavor string) (FlavorConfigTemplate, error) {
 	return tmplString, nil
 }
 
-// CreateConfig - function checks flavor specific parameters, get flavor's template and
+// CreateConfig function checks flavor specific parameters, get flavor's template and
 // create a config.
 func CreateConfig(flavor string, params map[string]string) (string, error) {
 	flavorData, err := GetFlavor(flavor)

--- a/pkg/flavors/flavors_test.go
+++ b/pkg/flavors/flavors_test.go
@@ -1,69 +1,83 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package flavor
 
 import (
 	"testing"
 )
 
+// Flavor for mocking and testing.
 type TestFlavor struct {
-  Test	string
+	Test string
 }
 
 var flavor TestFlavor
 
-
 func (TestFlavor) CreateConfig(params map[string]string) (error, string) {
-  return nil, "CreateTestConfig"
+	return nil, "CreateTestConfig"
 }
 
-func (TestFlavor)  CheckParams(params map[string]string) (error, interface{}) {
-	// Just set the 
+func (TestFlavor) CheckParams(params map[string]string) (error, interface{}) {
+	// Just set the
 	flavor.Test = "UnitTest"
 	return nil, flavor
 }
 
-func  (TestFlavor) GetTemplate() string {
+func (TestFlavor) GetTemplate() string {
 	return "This is {{ .Test }} template"
 }
+
 // Test adding and retrieving config template
 func TestAdd(t *testing.T) {
-  AddTemplate("test", flavor)
+	AddTemplate("test", flavor)
 
-  err, out := GetTemplate("test")
+	err, out := GetTemplate("test")
 
-  if err != nil {
-	  t.Error("Just added template cannot be located")
-  }
+	if err != nil {
+		t.Error("Just added template cannot be located")
+	}
 
-  if (flavor != out) {
-	  t.Error("Added and retrieved templates are different")
-  }
+	if flavor != out {
+		t.Error("Added and retrieved templates are different")
+	}
 }
 
 // Test retrieving non-existing template
 func TestGetNonExisting(t *testing.T) {
-  AddTemplate("test", flavor)
+	AddTemplate("test", flavor)
 
-  err, _ := GetTemplate("test1")
+	err, _ := GetTemplate("test1")
 
-  if err == nil {
-	  t.Error("Error should be returned for non-existing template")
-  }
+	if err == nil {
+		t.Error("Error should be returned for non-existing template")
+	}
 }
 
 // Test creating config.
 // Test verifies that after adding TestFlavor to the list
 // of known flavors, it can create a proper config.
 func TestCreateConfig(t *testing.T) {
-  AddTemplate("test", flavor)
+	AddTemplate("test", flavor)
 
-  params := map[string]string {"Test": "UnitTest"}
-  err, config := CreateConfig("test", params)
+	params := map[string]string{"Test": "UnitTest"}
+	err, config := CreateConfig("test", params)
 
-  if err != nil {
-    t.Error("Creating config failed with proper parameters")
-  }
+	if err != nil {
+		t.Error("Creating config failed with proper parameters")
+	}
 
-  if config != "This is UnitTest template" {
-    t.Errorf("Created config %s not as expected", config)
-  }
+	if config != "This is UnitTest template" {
+		t.Errorf("Created config %s not as expected", config)
+	}
 }

--- a/pkg/flavors/flavors_test.go
+++ b/pkg/flavors/flavors_test.go
@@ -5,15 +5,27 @@ import (
 )
 
 type TestFlavor struct {
+  Test	string
 }
+
+var flavor TestFlavor
+
 
 func (TestFlavor) CreateConfig(params map[string]string) (error, string) {
   return nil, "CreateTestConfig"
 }
+
+func (TestFlavor)  CheckParams(params map[string]string) (error, interface{}) {
+	// Just set the 
+	flavor.Test = "UnitTest"
+	return nil, flavor
+}
+
+func  (TestFlavor) GetTemplate() string {
+	return "This is {{ .Test }} template"
+}
 // Test adding and retrieving config template
 func TestAdd(t *testing.T) {
-  var flavor TestFlavor
-
   AddTemplate("test", flavor)
 
   err, out := GetTemplate("test")
@@ -29,8 +41,6 @@ func TestAdd(t *testing.T) {
 
 // Test retrieving non-existing template
 func TestGetNonExisting(t *testing.T) {
-  var flavor TestFlavor
-
   AddTemplate("test", flavor)
 
   err, _ := GetTemplate("test1")
@@ -38,5 +48,22 @@ func TestGetNonExisting(t *testing.T) {
   if err == nil {
 	  t.Error("Error should be returned for non-existing template")
   }
+}
 
+// Test creating config.
+// Test verifies that after adding TestFlavor to the list
+// of known flavors, it can create a proper config.
+func TestCreateConfig(t *testing.T) {
+  AddTemplate("test", flavor)
+
+  params := map[string]string {"Test": "UnitTest"}
+  err, config := CreateConfig("test", params)
+
+  if err != nil {
+    t.Error("Creating config failed with proper parameters")
+  }
+
+  if config != "This is UnitTest template" {
+    t.Errorf("Created config %s not as expected", config)
+  }
 }

--- a/pkg/flavors/flavors_test.go
+++ b/pkg/flavors/flavors_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package flavor
+package flavors
 
 import (
 	"testing"
@@ -24,14 +24,14 @@ type TestFlavor struct {
 
 var flavor TestFlavor
 
-func (TestFlavor) CreateConfig(params map[string]string) (error, string) {
-	return nil, "CreateTestConfig"
+func (TestFlavor) CreateConfig(params map[string]string) (string, error) {
+	return "CreateTestConfig", nil
 }
 
-func (TestFlavor) CheckParams(params map[string]string) (error, interface{}) {
+func (TestFlavor) CheckParams(params map[string]string) (interface{}, error) {
 	// Just set the
 	flavor.Test = "UnitTest"
-	return nil, flavor
+	return flavor, nil
 }
 
 func (TestFlavor) GetTemplate() string {
@@ -42,7 +42,7 @@ func (TestFlavor) GetTemplate() string {
 func TestAdd(t *testing.T) {
 	AddTemplate("test", flavor)
 
-	err, out := GetTemplate("test")
+	out, err := GetTemplate("test")
 
 	if err != nil {
 		t.Error("Just added template cannot be located")
@@ -57,7 +57,7 @@ func TestAdd(t *testing.T) {
 func TestGetNonExisting(t *testing.T) {
 	AddTemplate("test", flavor)
 
-	err, _ := GetTemplate("test1")
+	_, err := GetTemplate("test1")
 
 	if err == nil {
 		t.Error("Error should be returned for non-existing template")
@@ -71,7 +71,7 @@ func TestCreateConfig(t *testing.T) {
 	AddTemplate("test", flavor)
 
 	params := map[string]string{"Test": "UnitTest"}
-	err, config := CreateConfig("test", params)
+	config, err := CreateConfig("test", params)
 
 	if err != nil {
 		t.Error("Creating config failed with proper parameters")

--- a/pkg/flavors/flavors_test.go
+++ b/pkg/flavors/flavors_test.go
@@ -11,10 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package flavors
+package flavors_test
 
 import (
 	"testing"
+
+	"github.com/tetratelabs/getenvoy/pkg/flavors"
 )
 
 // Flavor for mocking and testing.
@@ -24,40 +26,38 @@ type TestFlavor struct {
 
 var flavor TestFlavor
 
-func (TestFlavor) CreateConfig(params map[string]string) (string, error) {
-	return "CreateTestConfig", nil
-}
-
-func (TestFlavor) CheckParams(params map[string]string) (interface{}, error) {
+func (f *TestFlavor) CheckParseParams(params map[string]string) error {
 	// Just set the
-	flavor.Test = "UnitTest"
-	return flavor, nil
+	f.Test = "UnitTest"
+	return nil
 }
 
-func (TestFlavor) GetTemplate() string {
-	return "This is {{ .Test }} template"
+const testTemplate string = "This is {{ .Test }} template"
+
+func (*TestFlavor) GetTemplate() string {
+	return testTemplate
 }
 
 // Test adding and retrieving config template
 func TestAdd(t *testing.T) {
-	AddTemplate("test", flavor)
+	flavors.AddFlavor("test", &flavor)
 
-	out, err := GetTemplate("test")
+	out, err := flavors.GetFlavor("test")
 
 	if err != nil {
 		t.Error("Just added template cannot be located")
 	}
 
-	if flavor != out {
+	if testTemplate != out.GetTemplate() {
 		t.Error("Added and retrieved templates are different")
 	}
 }
 
 // Test retrieving non-existing template
 func TestGetNonExisting(t *testing.T) {
-	AddTemplate("test", flavor)
+	flavors.AddFlavor("test", &flavor)
 
-	_, err := GetTemplate("test1")
+	_, err := flavors.GetFlavor("test1")
 
 	if err == nil {
 		t.Error("Error should be returned for non-existing template")
@@ -68,10 +68,10 @@ func TestGetNonExisting(t *testing.T) {
 // Test verifies that after adding TestFlavor to the list
 // of known flavors, it can create a proper config.
 func TestCreateConfig(t *testing.T) {
-	AddTemplate("test", flavor)
+	flavors.AddFlavor("test", &flavor)
 
 	params := map[string]string{"Test": "UnitTest"}
-	config, err := CreateConfig("test", params)
+	config, err := flavors.CreateConfig("test", params)
 
 	if err != nil {
 		t.Error("Creating config failed with proper parameters")

--- a/pkg/flavors/flavors_test.go
+++ b/pkg/flavors/flavors_test.go
@@ -26,30 +26,23 @@ type TestFlavor struct {
 
 var flavor TestFlavor
 
-func (f *TestFlavor) CheckParseParams(params map[string]string) error {
-	// Just set the
-	f.Test = "UnitTest"
-	return nil
-}
+const testConfig string = "This is UnitTest config"
 
-const testTemplate string = "This is {{ .Test }} template"
-
-func (*TestFlavor) GetTemplate() string {
-	return testTemplate
+func (f *TestFlavor) GenerateConfig(params map[string]string) (string, error) {
+	// Just return predefined value.
+	// Normally a flavor would use template but
+	// here using templates is not part of the test.
+	return testConfig, nil
 }
 
 // Test adding and retrieving config template
 func TestAdd(t *testing.T) {
 	flavors.AddFlavor("test", &flavor)
 
-	out, err := flavors.GetFlavor("test")
+	_, err := flavors.GetFlavor("test")
 
 	if err != nil {
 		t.Error("Just added template cannot be located")
-	}
-
-	if testTemplate != out.GetTemplate() {
-		t.Error("Added and retrieved templates are different")
 	}
 }
 
@@ -77,7 +70,7 @@ func TestCreateConfig(t *testing.T) {
 		t.Error("Creating config failed with proper parameters")
 	}
 
-	if config != "This is UnitTest template" {
+	if config != testConfig {
 		t.Errorf("Created config %s not as expected", config)
 	}
 }

--- a/pkg/flavors/flavors_test.go
+++ b/pkg/flavors/flavors_test.go
@@ -1,0 +1,42 @@
+package flavor
+
+import (
+	"testing"
+)
+
+type TestFlavor struct {
+}
+
+func (TestFlavor) CreateConfig(params map[string]string) (error, string) {
+  return nil, "CreateTestConfig"
+}
+// Test adding and retrieving config template
+func TestAdd(t *testing.T) {
+  var flavor TestFlavor
+
+  AddTemplate("test", flavor)
+
+  err, out := GetTemplate("test")
+
+  if err != nil {
+	  t.Error("Just added template cannot be located")
+  }
+
+  if (flavor != out) {
+	  t.Error("Added and retrieved templates are different")
+  }
+}
+
+// Test retrieving non-existing template
+func TestGetNonExisting(t *testing.T) {
+  var flavor TestFlavor
+
+  AddTemplate("test", flavor)
+
+  err, _ := GetTemplate("test1")
+
+  if err == nil {
+	  t.Error("Error should be returned for non-existing template")
+  }
+
+}

--- a/pkg/flavors/postgres/postgres.go
+++ b/pkg/flavors/postgres/postgres.go
@@ -70,7 +70,7 @@ func (Flavor) CheckParams(params map[string]string) (interface{}, error) {
 			notFound += key + " "
 		}
 	}
-	if len(notFound) != 0 {
+	if notFound != "" {
 		return nil, fmt.Errorf("Required template params %s were not specified", notFound)
 	}
 

--- a/pkg/flavors/postgres/postgres.go
+++ b/pkg/flavors/postgres/postgres.go
@@ -23,6 +23,7 @@ import (
 
 	valid "github.com/asaskevich/govalidator"
 	"github.com/tetratelabs/getenvoy/pkg/flavors"
+	"github.com/tetratelabs/log"
 )
 
 // Define template parameter names
@@ -101,7 +102,7 @@ func (f *Flavor) parseInputParams(params map[string]string) error {
 			}
 			f.InPort = value
 		default:
-			fmt.Printf("Ignoring unrecognized template parameter: %s", param)
+			log.Warnf("Ignoring unrecognized template parameter: %s", param)
 		}
 	}
 
@@ -148,7 +149,7 @@ func parseSingleEndpoint(endpoint string) (*clusterEndpoint, error) {
 	}
 
 	// This is just IP address or domain name.
-	isIP := (net.ParseIP(host) != nil)
+	isIP := net.ParseIP(host) != nil
 
 	return &clusterEndpoint{
 		EndpointAddr: host,

--- a/pkg/flavors/postgres/postgres.go
+++ b/pkg/flavors/postgres/postgres.go
@@ -26,8 +26,8 @@ import (
 )
 
 // Define template parameter names
-const endpoint string = "endpoint"
-const inport string = "inport"
+const endpointsParam string = "endpoints"
+const inportParam string = "inport"
 
 // Flavor implements flavor.FlavorConfigTemplate interface
 // and stores config data specific to Postgres template.
@@ -90,12 +90,12 @@ func (f *Flavor) parseInputParams(params map[string]string) error {
 
 	for param, value := range params {
 		switch param {
-		case endpoint:
+		case endpointsParam:
 			f.endpoints, err = parseEndpointSet(value)
 			if err != nil {
 				return err
 			}
-		case inport:
+		case inportParam:
 			if !valid.IsInt(value) {
 				return fmt.Errorf("Value for templateArg %s must be integer number", param)
 			}
@@ -107,7 +107,7 @@ func (f *Flavor) parseInputParams(params map[string]string) error {
 
 	// Check if all required params have been found in the parameter list
 	if len(f.endpoints) == 0 {
-		return fmt.Errorf("endpoint parameter must be specified")
+		return fmt.Errorf("Parameter endpoints must be specified")
 	}
 
 	// Verify that all endpoints are of the same type:

--- a/pkg/flavors/postgres/postgres.go
+++ b/pkg/flavors/postgres/postgres.go
@@ -183,11 +183,14 @@ func (f *Flavor) generateEndpointSetConfig() (string, error) {
 	if err != nil {
 		// Template is not supplied by a user, but is compiled-in, so this error should
 		// happen only during development time.
-		return "", fmt.Errorf("Supplied postgres-main template is incorrect")
+		return "", fmt.Errorf("Cannot parse postgres endpoint template")
 	}
 
 	for _, singleEndpoint := range f.endpoints {
-		tmpl.Execute(&buf, singleEndpoint) //nolint
+		err = tmpl.Execute(&buf, singleEndpoint)
+		if err != nil {
+			return "", fmt.Errorf("Cannot execute postgres endpoint template")
+		}
 	}
 
 	return buf.String(), nil
@@ -206,9 +209,12 @@ func (f *Flavor) generateMainConfig() (string, error) {
 	if err != nil {
 		// Template is not supplied by a user, but is compiled-in, so this error should
 		// happen only during development time.
-		return "", fmt.Errorf("Supplied postgres-main template is incorrect")
+		return "", fmt.Errorf("Cannot parse postgres main template")
 	}
-	tmpl.Execute(&buf, f) //nolint
+	err = tmpl.Execute(&buf, f)
+	if err != nil {
+		return "", fmt.Errorf("Cannot execute postgres main template")
+	}
 
 	return buf.String(), nil
 }

--- a/pkg/flavors/postgres/postgres.go
+++ b/pkg/flavors/postgres/postgres.go
@@ -1,0 +1,94 @@
+package postgres
+
+import (
+	"fmt"
+	"os"
+	"text/template"
+	"github.com/tetratelabs/getenvoy/pkg/flavors"
+)
+
+type PostgresFlavor struct {
+	// The following params are required for template to be processed successfully
+	Endpoint string
+}
+
+var postgresFlavor PostgresFlavor
+
+func init () {
+	flavor.AddTemplate("postgres", postgresFlavor)
+}
+
+
+func (PostgresFlavor) CreateConfig(params map[string]string) (error, string) {
+	required := map[string]int {"Endpoint": 0}
+
+	for  param, _ := range params {
+		if _, ok := required[param]; ok {
+			required[param]++
+			postgresFlavor.Endpoint = params[param]
+		}
+	}
+
+	// Check if all required params have been found in the parameter list
+	var notFound string
+	for key, count := range required {
+		if count == 0 {
+			notFound += key + " "
+		}
+	}
+	if len(notFound) != 0 {
+		return fmt.Errorf("Template params %s were not specified", notFound), ""
+	}
+
+	// NOw run the template substitution
+	tmpl := template.New("config")
+	tmpl, err := tmpl.Parse(configTemplate)
+	if err != nil {
+		return fmt.Errorf("Supplied template for flavor %s is incorrect.", "postgres"), ""
+	}
+	tmpl.Execute(os.Stdout, postgresFlavor) 
+
+	return nil, ""
+}
+
+var configTemplate string = 
+`static_resources:
+  listeners:
+  - name: postgres_listener
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 1968
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.postgres_proxy
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.postgres_proxy.v3alpha.PostgresProxy
+          stat_prefix: egress_postgres
+      - name: envoy.tcp_proxy
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          stat_prefix: postgres_tcp
+          cluster: postgres_cluster
+
+  clusters:
+  - name: postgres_cluster
+    connect_timeout: 1s
+    type: static
+    load_assignment:
+      cluster_name: postgres_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: {{ .Endpoint}} 
+                port_value: 5432
+
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001`
+

--- a/pkg/flavors/postgres/postgres.go
+++ b/pkg/flavors/postgres/postgres.go
@@ -1,70 +1,60 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package postgres
 
 import (
 	"fmt"
-	"github.com/tetratelabs/getenvoy/pkg/flavors"
 	valid "github.com/asaskevich/govalidator"
+	"github.com/tetratelabs/getenvoy/pkg/flavors"
 )
 
 // Define template parameter names
 const Endpoint string = "Endpoint"
-const InPort   string = "InPort"
+const InPort string = "InPort"
 
 type PostgresFlavor struct {
-	// Location of the postgres server 
+	// Location of the postgres server
 	Endpoint string
 	// Envoy's listener port
-	InPort   string
+	InPort string
 }
 
 var postgresFlavor PostgresFlavor
 
-func init () {
+func init() {
 	// Set default values.
 	// Default values are not required to be present in cmd line.
 	postgresFlavor.InPort = "5432"
 	flavor.AddTemplate("postgres", postgresFlavor)
 }
 
-
-func (PostgresFlavor) CreateConfig(params map[string]string) (error, string) {
-	required := map[string]int {Endpoint: 0}
-
-	for  param, _ := range params {
-		if _, ok := required[param]; ok {
-			required[param]++
-			postgresFlavor.Endpoint = params[param]
-		}
-	}
-
-	// Check if all required params have been found in the parameter list
-	var notFound string
-	for key, count := range required {
-		if count == 0 {
-			notFound += key + " "
-		}
-	}
-	if len(notFound) != 0 {
-		return fmt.Errorf("Template params %s were not specified", notFound), ""
-	}
-
-	return nil, ""
-}
- 
-
+// Method verifies that passed template arguments are correct and
+// are sufficient for creating a valid config from template.
 func (PostgresFlavor) CheckParams(params map[string]string) (error, interface{}) {
-	required := map[string]int {Endpoint: 0}
+	required := map[string]int{Endpoint: 0}
 
-	for  param, value := range params {
+	for param, value := range params {
 		switch param {
 		case Endpoint:
 			required[param]++
-			postgresFlavor.Endpoint = value 
+			postgresFlavor.Endpoint = value
 		case InPort:
 			if !valid.IsInt(value) {
 				return fmt.Errorf("Value for templateArg %s must be integer number", param), nil
 			}
-			postgresFlavor.InPort = value 
+			postgresFlavor.InPort = value
 		default:
 			fmt.Printf("Ignoring unrecognized template parameter: %s", param)
 		}
@@ -87,12 +77,9 @@ func (PostgresFlavor) CheckParams(params map[string]string) (error, interface{})
 func (PostgresFlavor) GetTemplate() string {
 	return configTemplate
 }
- 
-
 
 // Postgres specific config file.
-var configTemplate string = 
-`static_resources:
+var configTemplate string = `static_resources:
   listeners:
   - name: postgres_listener
     address:
@@ -131,4 +118,3 @@ admin:
     socket_address:
       address: 0.0.0.0
       port_value: 8001`
-

--- a/pkg/flavors/postgres/postgres_test.go
+++ b/pkg/flavors/postgres/postgres_test.go
@@ -1,82 +1,94 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package postgres
 
 import (
+	"github.com/tetratelabs/getenvoy/pkg/flavors"
 	"testing"
-        "github.com/tetratelabs/getenvoy/pkg/flavors"
 )
-
 
 // Test verifies that postgres flavor is registered when module is loaded.
 func TestInit(t *testing.T) {
-  err, _ := flavor.GetTemplate("postgres")
+	err, _ := flavor.GetTemplate("postgres")
 
-  if err != nil {
-	  t.Error("postgres flavor should be registered at init phase.")
-  }
+	if err != nil {
+		t.Error("postgres flavor should be registered at init phase.")
+	}
 }
 
 // Create set of template argumments which do not include
 // required one called "endpoint"
 func TestMissingParam(t *testing.T) {
 
-  params := map[string]string {
-	  "blah": "bleh",
-  }
-  var testFlavor PostgresFlavor
+	params := map[string]string{
+		"blah": "bleh",
+	}
+	var testFlavor PostgresFlavor
 
-  err, _ := testFlavor.CheckParams(params)
+	err, _ := testFlavor.CheckParams(params)
 
-  if err == nil {
-	  t.Error("Not specifying mandatory template args does not trigger error")
-  }
+	if err == nil {
+		t.Error("Not specifying mandatory template args does not trigger error")
+	}
 }
 
 // Verify that passing all required params does not trigger any arror.
 func TestAllParams(t *testing.T) {
-  params := map[string]string {
+	params := map[string]string{
 		"Endpoint": "127.0.0.1",
 	}
-  var testFlavor PostgresFlavor
+	var testFlavor PostgresFlavor
 
-  err, data := testFlavor.CheckParams(params)
+	err, data := testFlavor.CheckParams(params)
 
-  if err != nil {
-	  t.Errorf("All required params were passed but check failed: %s", err)
-  }
+	if err != nil {
+		t.Errorf("All required params were passed but check failed: %s", err)
+	}
 
-  // Type assertion from generic interface{} to PostgresFlavor.
-  postgresData := data.(PostgresFlavor)
-  if postgresData.Endpoint != "127.0.0.1" {
-	  t.Errorf("Parsing template params does not create proper structure")
-  }
+	// Type assertion from generic interface{} to PostgresFlavor.
+	postgresData := data.(PostgresFlavor)
+	if postgresData.Endpoint != "127.0.0.1" {
+		t.Errorf("Parsing template params does not create proper structure")
+	}
 }
 
-// Verify that as long as required params are included template processing 
+// Verify that as long as required params are included template processing
 // is successful
-func TestExtraParams(t * testing.T) {
-  params := map[string]string {
+func TestExtraParams(t *testing.T) {
+	params := map[string]string{
 		"Endpoint": "127.0.0.1",
-		"blah": "blah",
+		"blah":     "blah",
 	}
-  var testFlavor PostgresFlavor
+	var testFlavor PostgresFlavor
 
-  err, data := testFlavor.CheckParams(params)
+	err, data := testFlavor.CheckParams(params)
 
-  if err != nil {
-	  t.Errorf("All required params were passed but check failed: %s", err)
-  }
+	if err != nil {
+		t.Errorf("All required params were passed but check failed: %s", err)
+	}
 
-  // Type assertion from generic interface{} to PostgresFlavor.
-  postgresData := data.(PostgresFlavor)
-  if postgresData.Endpoint != "127.0.0.1" {
-	  t.Errorf("Parsing template params does not create proper structure")
-  }
+	// Type assertion from generic interface{} to PostgresFlavor.
+	postgresData := data.(PostgresFlavor)
+	if postgresData.Endpoint != "127.0.0.1" {
+		t.Errorf("Parsing template params does not create proper structure")
+	}
 }
 
 // Make sure the GetTemplate returns the correct config.
-func TestGetTemplate(t * testing.T) {
-  var testFlavor PostgresFlavor
-  if configTemplate != testFlavor.GetTemplate() {
-	  t.Errorf("Wrong config template returned.")
-  }
+func TestGetTemplate(t *testing.T) {
+	var testFlavor PostgresFlavor
+	if configTemplate != testFlavor.GetTemplate() {
+		t.Errorf("Wrong config template returned.")
+	}
 }

--- a/pkg/flavors/postgres/postgres_test.go
+++ b/pkg/flavors/postgres/postgres_test.go
@@ -1,0 +1,62 @@
+package postgres
+
+import (
+	"testing"
+        "github.com/tetratelabs/getenvoy/pkg/flavors"
+)
+
+
+// Test verifies that postgres flavor is registered when module is loaded.
+func TestInit(t *testing.T) {
+  err, _ := flavor.GetTemplate("postgres")
+
+  if err != nil {
+	  t.Error("postgres flavor should be registered at init phase.")
+  }
+}
+
+// Create set of template argumments which do not include
+// required one called "endpoint"
+func TestMissingParam(t *testing.T) {
+
+  params := map[string]string {
+	  "blah": "bleh",
+  }
+  var testFlavor PostgresFlavor
+
+  err, _ := testFlavor.CreateConfig(params)
+
+  if err == nil {
+	  t.Error("Not specifying mandatory template args does not trigger error")
+  }
+}
+
+// Verify that passing all required params does not trigger any arror.
+func TestCreateConfig(t *testing.T) {
+  params := map[string]string {
+		"Endpoint": "127.0.0.1",
+	}
+  var testFlavor PostgresFlavor
+
+  err, _ := testFlavor.CreateConfig(params)
+
+  if err != nil {
+	  t.Errorf("Creating config failed: %s", err)
+  }
+}
+
+// Verify that as long as required params are included template processing 
+// is successful
+func TestExtraParams(t * testing.T) {
+  params := map[string]string {
+		"Endpoint": "127.0.0.1",
+		"blah": "blah",
+	}
+  var testFlavor PostgresFlavor
+
+  err, _ := testFlavor.CreateConfig(params)
+
+  if err != nil {
+	  t.Errorf("Creating config failed: %s", err)
+  }
+}

--- a/pkg/flavors/postgres/postgres_test.go
+++ b/pkg/flavors/postgres/postgres_test.go
@@ -30,7 +30,7 @@ func TestInit(t *testing.T) {
 }
 
 type testInputEndpoint struct {
-	endpoint    string
+	endpoints   string
 	parseResult clusterEndpoint
 	result      bool
 }
@@ -57,15 +57,15 @@ func TestParseSingleEndpoint(t *testing.T) {
 	}
 
 	for _, testCase := range input {
-		parsed, err := parseSingleEndpoint(testCase.endpoint)
+		parsed, err := parseSingleEndpoint(testCase.endpoints)
 		if testCase.result != (err == nil) {
-			t.Errorf("Parsing result for %s not as expected", testCase.endpoint)
+			t.Errorf("Parsing result for %s not as expected", testCase.endpoints)
 		}
 		if err != nil {
 			continue
 		}
 		if *parsed != testCase.parseResult {
-			t.Errorf("Parsed structure %v for %s is not as expected", *parsed, testCase.endpoint)
+			t.Errorf("Parsed structure %v for %s is not as expected", *parsed, testCase.endpoints)
 		}
 	}
 }
@@ -117,14 +117,14 @@ type testInputCmdParams struct {
 func TestInputCmdParams(t *testing.T) {
 	var testFlavor Flavor
 	input := []testInputCmdParams{
-		{map[string]string{"endpoint": "127.0.0.1:3456"}, true},
-		{map[string]string{"endpoint1": "127.0.0.1:3456"}, false},
-		{map[string]string{"endpoint1": "127.0.0.1:3456", "endpoint": "128.0.0.1"}, true},
-		{map[string]string{"endpoint1": "127.0.0.1:3456", "inport": "128.0.0.1"}, false},
-		{map[string]string{"endpoint": "127.0.0.1:3456", "inport": "128.0.0.1"}, false},
-		{map[string]string{"endpoint": "127.0.0.1:3456", "inport": "5432"}, true},
-		{map[string]string{"endpoint": "127.0.0.1:blah", "inport": "5432"}, false},
-		{map[string]string{"endpoint": "127.0.0.1:3456,postgres:1234"}, false},
+		{map[string]string{"endpoints": "127.0.0.1:3456"}, true},
+		{map[string]string{"endpoints1": "127.0.0.1:3456"}, false},
+		{map[string]string{"endpoints1": "127.0.0.1:3456", "endpoints": "128.0.0.1"}, true},
+		{map[string]string{"endpoints1": "127.0.0.1:3456", "inport": "128.0.0.1"}, false},
+		{map[string]string{"endpoints": "127.0.0.1:3456", "inport": "128.0.0.1"}, false},
+		{map[string]string{"endpoints": "127.0.0.1:3456", "inport": "5432"}, true},
+		{map[string]string{"endpoints": "127.0.0.1:blah", "inport": "5432"}, false},
+		{map[string]string{"endpoints": "127.0.0.1:3456,postgres:1234"}, false},
 	}
 
 	for _, testCase := range input {
@@ -153,10 +153,10 @@ func TestCreateEndpointsConfig(t *testing.T) {
 	var testFlavor Flavor
 
 	input := []testEndpointSetConfig{
-		{map[string]string{"endpoint": "127.0.0.1:3456"}, []string{"127.0.0.1", "3456"}},
-		{map[string]string{"endpoint": "127.0.0.1:3456,128.0.0.1"}, []string{"127.0.0.1", "3456", "128.0.0.1", "5432"}},
-		{map[string]string{"endpoint": "postgres:3456"}, []string{"postgres", "3456"}},
-		{map[string]string{"endpoint": "postgres1:3456,postgres2"}, []string{"postgres1", "3456", "postgres2", "5432"}},
+		{map[string]string{"endpoints": "127.0.0.1:3456"}, []string{"127.0.0.1", "3456"}},
+		{map[string]string{"endpoints": "127.0.0.1:3456,128.0.0.1"}, []string{"127.0.0.1", "3456", "128.0.0.1", "5432"}},
+		{map[string]string{"endpoints": "postgres:3456"}, []string{"postgres", "3456"}},
+		{map[string]string{"endpoints": "postgres1:3456,postgres2"}, []string{"postgres1", "3456", "postgres2", "5432"}},
 	}
 
 	for index, testCase := range input {
@@ -186,10 +186,10 @@ func TestCreateMainConfig(t *testing.T) {
 	var testFlavor Flavor
 
 	input := []testEndpointSetConfig{
-		{map[string]string{"endpoint": "127.0.0.1:3456"}, []string{"static"}},
-		{map[string]string{"endpoint": "127.0.0.1:3456,128.0.0.1"}, []string{"static"}},
-		{map[string]string{"endpoint": "postgres:3456"}, []string{"strict_dns"}},
-		{map[string]string{"endpoint": "postgres1:3456,postgres2"}, []string{"strict_dns"}},
+		{map[string]string{"endpoints": "127.0.0.1:3456"}, []string{"static"}},
+		{map[string]string{"endpoints": "127.0.0.1:3456,128.0.0.1"}, []string{"static"}},
+		{map[string]string{"endpoints": "postgres:3456"}, []string{"strict_dns"}},
+		{map[string]string{"endpoints": "postgres1:3456,postgres2"}, []string{"strict_dns"}},
 	}
 
 	for index, testCase := range input {

--- a/pkg/flavors/postgres/postgres_test.go
+++ b/pkg/flavors/postgres/postgres_test.go
@@ -21,7 +21,7 @@ import (
 
 // Test verifies that postgres flavor is registered when module is loaded.
 func TestInit(t *testing.T) {
-	_, err := flavors.GetTemplate("postgres")
+	_, err := flavors.GetFlavor("postgres")
 
 	if err != nil {
 		t.Error("postgres flavor should be registered at init phase.")
@@ -29,15 +29,15 @@ func TestInit(t *testing.T) {
 }
 
 // Create set of template argumments which do not include
-// required one called "endpoint"
+// required one called "Endpoint"
 func TestMissingParam(t *testing.T) {
 
 	params := map[string]string{
 		"blah": "bleh",
 	}
-	var testFlavor Flavor
+	var testFlavor = &flavor
 
-	_, err := testFlavor.CheckParams(params)
+	err := testFlavor.CheckParseParams(params)
 
 	if err == nil {
 		t.Error("Not specifying mandatory template args does not trigger error")
@@ -47,19 +47,17 @@ func TestMissingParam(t *testing.T) {
 // Verify that passing all required params does not trigger any arror.
 func TestAllParams(t *testing.T) {
 	params := map[string]string{
-		"endpoint": "127.0.0.1",
+		"Endpoint": "127.0.0.1",
 	}
-	var testFlavor Flavor
+	var testFlavor = &flavor
 
-	data, err := testFlavor.CheckParams(params)
+	err := testFlavor.CheckParseParams(params)
 
 	if err != nil {
 		t.Errorf("All required params were passed but check failed: %s", err)
 	}
 
-	// Type assertion from generic interface{} to Flavor.
-	postgresData := data.(Flavor)
-	if postgresData.endpoint != "127.0.0.1" {
+	if testFlavor.Endpoint != "127.0.0.1" {
 		t.Errorf("Parsing template params does not create proper structure")
 	}
 }
@@ -68,20 +66,18 @@ func TestAllParams(t *testing.T) {
 // is successful
 func TestExtraParams(t *testing.T) {
 	params := map[string]string{
-		"endpoint": "127.0.0.1",
+		"Endpoint": "127.0.0.1",
 		"blah":     "blah",
 	}
-	var testFlavor Flavor
+	var testFlavor = &flavor
 
-	data, err := testFlavor.CheckParams(params)
+	err := testFlavor.CheckParseParams(params)
 
 	if err != nil {
 		t.Errorf("All required params were passed but check failed: %s", err)
 	}
 
-	// Type assertion from generic interface{} to Flavor.
-	postgresData := data.(Flavor)
-	if postgresData.endpoint != "127.0.0.1" {
+	if testFlavor.Endpoint != "127.0.0.1" {
 		t.Errorf("Parsing template params does not create proper structure")
 	}
 }

--- a/pkg/flavors/postgres/postgres_test.go
+++ b/pkg/flavors/postgres/postgres_test.go
@@ -115,7 +115,6 @@ type testInputCmdParams struct {
 // Test verifies that parsing input parameters should fail
 // when endpoint is not specified and when specified port has wrong format.
 func TestInputCmdParams(t *testing.T) {
-	var testFlavor Flavor
 	input := []testInputCmdParams{
 		{map[string]string{"endpoints": "127.0.0.1:3456"}, true},
 		{map[string]string{"endpoints1": "127.0.0.1:3456"}, false},
@@ -128,7 +127,7 @@ func TestInputCmdParams(t *testing.T) {
 	}
 
 	for _, testCase := range input {
-		testFlavor.endpoints = testFlavor.endpoints[:0]
+		var testFlavor Flavor
 		err := testFlavor.parseInputParams(testCase.params)
 
 		if testCase.result != (err == nil) {

--- a/pkg/flavors/postgres/postgres_test.go
+++ b/pkg/flavors/postgres/postgres_test.go
@@ -24,7 +24,7 @@ func TestMissingParam(t *testing.T) {
   }
   var testFlavor PostgresFlavor
 
-  err, _ := testFlavor.CreateConfig(params)
+  err, _ := testFlavor.CheckParams(params)
 
   if err == nil {
 	  t.Error("Not specifying mandatory template args does not trigger error")
@@ -32,16 +32,22 @@ func TestMissingParam(t *testing.T) {
 }
 
 // Verify that passing all required params does not trigger any arror.
-func TestCreateConfig(t *testing.T) {
+func TestAllParams(t *testing.T) {
   params := map[string]string {
 		"Endpoint": "127.0.0.1",
 	}
   var testFlavor PostgresFlavor
 
-  err, _ := testFlavor.CreateConfig(params)
+  err, data := testFlavor.CheckParams(params)
 
   if err != nil {
-	  t.Errorf("Creating config failed: %s", err)
+	  t.Errorf("All required params were passed but check failed: %s", err)
+  }
+
+  // Type assertion from generic interface{} to PostgresFlavor.
+  postgresData := data.(PostgresFlavor)
+  if postgresData.Endpoint != "127.0.0.1" {
+	  t.Errorf("Parsing template params does not create proper structure")
   }
 }
 
@@ -54,9 +60,23 @@ func TestExtraParams(t * testing.T) {
 	}
   var testFlavor PostgresFlavor
 
-  err, _ := testFlavor.CreateConfig(params)
+  err, data := testFlavor.CheckParams(params)
 
   if err != nil {
-	  t.Errorf("Creating config failed: %s", err)
+	  t.Errorf("All required params were passed but check failed: %s", err)
+  }
+
+  // Type assertion from generic interface{} to PostgresFlavor.
+  postgresData := data.(PostgresFlavor)
+  if postgresData.Endpoint != "127.0.0.1" {
+	  t.Errorf("Parsing template params does not create proper structure")
+  }
+}
+
+// Make sure the GetTemplate returns the correct config.
+func TestGetTemplate(t * testing.T) {
+  var testFlavor PostgresFlavor
+  if configTemplate != testFlavor.GetTemplate() {
+	  t.Errorf("Wrong config template returned.")
   }
 }

--- a/pkg/flavors/postgres/postgres_test.go
+++ b/pkg/flavors/postgres/postgres_test.go
@@ -14,13 +14,14 @@
 package postgres
 
 import (
-	"github.com/tetratelabs/getenvoy/pkg/flavors"
 	"testing"
+
+	"github.com/tetratelabs/getenvoy/pkg/flavors"
 )
 
 // Test verifies that postgres flavor is registered when module is loaded.
 func TestInit(t *testing.T) {
-	err, _ := flavor.GetTemplate("postgres")
+	_, err := flavors.GetTemplate("postgres")
 
 	if err != nil {
 		t.Error("postgres flavor should be registered at init phase.")
@@ -34,9 +35,9 @@ func TestMissingParam(t *testing.T) {
 	params := map[string]string{
 		"blah": "bleh",
 	}
-	var testFlavor PostgresFlavor
+	var testFlavor Flavor
 
-	err, _ := testFlavor.CheckParams(params)
+	_, err := testFlavor.CheckParams(params)
 
 	if err == nil {
 		t.Error("Not specifying mandatory template args does not trigger error")
@@ -46,19 +47,19 @@ func TestMissingParam(t *testing.T) {
 // Verify that passing all required params does not trigger any arror.
 func TestAllParams(t *testing.T) {
 	params := map[string]string{
-		"Endpoint": "127.0.0.1",
+		"endpoint": "127.0.0.1",
 	}
-	var testFlavor PostgresFlavor
+	var testFlavor Flavor
 
-	err, data := testFlavor.CheckParams(params)
+	data, err := testFlavor.CheckParams(params)
 
 	if err != nil {
 		t.Errorf("All required params were passed but check failed: %s", err)
 	}
 
-	// Type assertion from generic interface{} to PostgresFlavor.
-	postgresData := data.(PostgresFlavor)
-	if postgresData.Endpoint != "127.0.0.1" {
+	// Type assertion from generic interface{} to Flavor.
+	postgresData := data.(Flavor)
+	if postgresData.endpoint != "127.0.0.1" {
 		t.Errorf("Parsing template params does not create proper structure")
 	}
 }
@@ -67,27 +68,27 @@ func TestAllParams(t *testing.T) {
 // is successful
 func TestExtraParams(t *testing.T) {
 	params := map[string]string{
-		"Endpoint": "127.0.0.1",
+		"endpoint": "127.0.0.1",
 		"blah":     "blah",
 	}
-	var testFlavor PostgresFlavor
+	var testFlavor Flavor
 
-	err, data := testFlavor.CheckParams(params)
+	data, err := testFlavor.CheckParams(params)
 
 	if err != nil {
 		t.Errorf("All required params were passed but check failed: %s", err)
 	}
 
-	// Type assertion from generic interface{} to PostgresFlavor.
-	postgresData := data.(PostgresFlavor)
-	if postgresData.Endpoint != "127.0.0.1" {
+	// Type assertion from generic interface{} to Flavor.
+	postgresData := data.(Flavor)
+	if postgresData.endpoint != "127.0.0.1" {
 		t.Errorf("Parsing template params does not create proper structure")
 	}
 }
 
 // Make sure the GetTemplate returns the correct config.
 func TestGetTemplate(t *testing.T) {
-	var testFlavor PostgresFlavor
+	var testFlavor Flavor
 	if configTemplate != testFlavor.GetTemplate() {
 		t.Errorf("Wrong config template returned.")
 	}


### PR DESCRIPTION
Added logic to recognize _postgres_ flavor and bootstrap config based on template and command line parameters.

Command line parameters are specified by --templateArg. More than one templateArg may be specified. For Postgres a user must specify Endpoint, like --templateArg Endpoint=127.0.0.1

Additional parameter is InPort, which is Envoy's listening port. If not specified the value of InPort defaults to 5432.
To overwrite InPort, cmd line should contain --templateArg InPort=5433