### PR TITLE
ci: fix `make builders.push BUILDERS_TAG=latest`

### DIFF
--- a/.github/workflows/builders.yml
+++ b/.github/workflows/builders.yml
@@ -29,7 +29,11 @@ jobs:
     - name: Push the Docker image
       run: make builders.push BUILDERS_TAG=${{ github.sha }}
       if: github.event_name == 'push'
-    
-    - name: Mark the Docker image latest
+
+    - name: Tag the Docker image as 'latest'
+      run: make builders.tag BUILDERS_TAG=${{ github.sha }} EXTRA_TAG=latest
+      if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+
+    - name: Push the 'latest' Docker image
       run: make builders.push BUILDERS_TAG=latest
       if: github.ref == 'refs/heads/master' && github.event_name == 'push'

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ HUB ?= docker.io/getenvoy
 GETENVOY_TAG ?= dev
 BUILDERS_LANGS := rust
 BUILDERS_TAG ?= latest
+EXTRA_TAG ?=
 
 USE_DOCKER_BUILDKIT_CACHE ?= yes
 ifneq ($(filter-out yes on true 1,$(USE_DOCKER_BUILDKIT_CACHE)),)
@@ -148,6 +149,16 @@ $(foreach lang,$(BUILDERS_LANGS),$(eval $(call GEN_PUSH_EXTENSION_BUILDER_IMAGE_
 
 .PHONY: builders.push
 builders.push: $(foreach lang,$(BUILDERS_LANGS), push/builder/$(lang))
+
+define GEN_TAG_EXTENSION_BUILDER_IMAGE_TARGET
+.PHONY: tag/builder/$(1)
+tag/builder/$(1):
+	docker tag $(call EXTENSION_BUILDER_IMAGE,$(1),$(BUILDERS_TAG)) $(call EXTENSION_BUILDER_IMAGE,$(1),$(EXTRA_TAG))
+endef
+$(foreach lang,$(BUILDERS_LANGS),$(eval $(call GEN_TAG_EXTENSION_BUILDER_IMAGE_TARGET,$(lang))))
+
+.PHONY: builders.tag
+builders.tag: $(foreach lang,$(BUILDERS_LANGS), tag/builder/$(lang))
 
 define GEN_PULL_EXTENSION_BUILDER_IMAGE_TARGET
 .PHONY: pull/builder/$(1)


### PR DESCRIPTION
## Summary

* fix CI build that fails on attempt to `docker push` the `latest` builder image, while `latest` tag has never been added