### PR TITLE
Change the default Wasm runtime to Envoy 1.17 from wasm:1.15

### DIFF
--- a/data/extension/init/templates/rust/envoy.access_loggers/default/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.access_loggers/default/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["wasm"]
 crate-type = ["rlib"]
 
 [dependencies]
-envoy = { package = "envoy-sdk", version = "^0.1" }
+envoy = { package = "envoy-sdk", version = "^0.2" }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 chrono = "^0.4"

--- a/data/extension/init/templates/rust/envoy.access_loggers/default/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.access_loggers/default/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["wasm"]
 crate-type = ["rlib"]
 
 [dependencies]
-envoy = { package = "envoy-sdk", version = "^0.2" }
+envoy = { package = "envoy-sdk", version = "^0.2.0-alpha.1" }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 chrono = "^0.4"

--- a/data/extension/init/templates/rust/envoy.access_loggers/default/wasm/module/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.access_loggers/default/wasm/module/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 envoy-sample-access-logger = { path = "../.." }
-envoy = { package = "envoy-sdk", version = "^0.1" }
+envoy = { package = "envoy-sdk", version = "^0.2" }

--- a/data/extension/init/templates/rust/envoy.access_loggers/default/wasm/module/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.access_loggers/default/wasm/module/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 envoy-sample-access-logger = { path = "../.." }
-envoy = { package = "envoy-sdk", version = "^0.2" }
+envoy = { package = "envoy-sdk", version = "^0.2.0-alpha.1" }

--- a/data/extension/init/templates/rust/envoy.filters.http/default/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.filters.http/default/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["wasm"]
 crate-type = ["rlib"]
 
 [dependencies]
-envoy = { package = "envoy-sdk", version = "^0.1" }
+envoy = { package = "envoy-sdk", version = "^0.2" }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 chrono = "^0.4"

--- a/data/extension/init/templates/rust/envoy.filters.http/default/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.filters.http/default/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["wasm"]
 crate-type = ["rlib"]
 
 [dependencies]
-envoy = { package = "envoy-sdk", version = "^0.2" }
+envoy = { package = "envoy-sdk", version = "^0.2.0-alpha.1" }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 chrono = "^0.4"

--- a/data/extension/init/templates/rust/envoy.filters.http/default/wasm/module/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.filters.http/default/wasm/module/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 envoy-sample-http-filter = { path = "../.." }
-envoy = { package = "envoy-sdk", version = "^0.2" }
+envoy = { package = "envoy-sdk", version = "^0.2.0-alpha.1" }

--- a/data/extension/init/templates/rust/envoy.filters.http/default/wasm/module/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.filters.http/default/wasm/module/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 envoy-sample-http-filter = { path = "../.." }
-envoy = { package = "envoy-sdk", version = "^0.1" }
+envoy = { package = "envoy-sdk", version = "^0.2" }

--- a/data/extension/init/templates/rust/envoy.filters.network/default/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.filters.network/default/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["wasm"]
 crate-type = ["rlib"]
 
 [dependencies]
-envoy = { package = "envoy-sdk", version = "^0.1" }
+envoy = { package = "envoy-sdk", version = "^0.2" }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 chrono = "^0.4"

--- a/data/extension/init/templates/rust/envoy.filters.network/default/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.filters.network/default/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["wasm"]
 crate-type = ["rlib"]
 
 [dependencies]
-envoy = { package = "envoy-sdk", version = "^0.2" }
+envoy = { package = "envoy-sdk", version = "^0.2.0-alpha.1" }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 chrono = "^0.4"

--- a/data/extension/init/templates/rust/envoy.filters.network/default/wasm/module/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.filters.network/default/wasm/module/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 envoy-sample-network-filter = { path = "../.." }
-envoy = { package = "envoy-sdk", version = "^0.2" }
+envoy = { package = "envoy-sdk", version = "^0.2.0-alpha.1" }

--- a/data/extension/init/templates/rust/envoy.filters.network/default/wasm/module/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.filters.network/default/wasm/module/Cargo.toml
@@ -14,4 +14,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 envoy-sample-network-filter = { path = "../.." }
-envoy = { package = "envoy-sdk", version = "^0.1" }
+envoy = { package = "envoy-sdk", version = "^0.2" }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	bitbucket.org/creachadair/shell v0.0.6
+	github.com/Masterminds/semver v1.5.0
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITgsTc=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.14.1+incompatible h1:rTHERm50Xp1Cbb8x7xBCeDp//jMMqqR44EWw7KwSXUQ=
 github.com/Masterminds/sprig v2.14.1+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/pkg/cmd/extension/build/testdata/workspace/.getenvoy/extension/extension.yaml
+++ b/pkg/cmd/extension/build/testdata/workspace/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/cmd/extension/example/testdata/workspace1/.getenvoy/extension/extension.yaml
+++ b/pkg/cmd/extension/example/testdata/workspace1/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/cmd/extension/example/testdata/workspace2/.getenvoy/extension/extension.yaml
+++ b/pkg/cmd/extension/example/testdata/workspace2/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/cmd/extension/example/testdata/workspace3/.getenvoy/extension/extension.yaml
+++ b/pkg/cmd/extension/example/testdata/workspace3/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/cmd/extension/init/cmd.go
+++ b/pkg/cmd/extension/init/cmd.go
@@ -54,7 +54,7 @@ var (
 	// 1. according to command-line options
 	// 2. otherwise, according to the example-specific configuration (.getenvoy/extension/examples/<example>/example.yaml)
 	// 3. otherwise, according to extension descriptor (.getenvoy/extension/extension.yaml)
-	supportedEnvoyVersion = "wasm:1.15"
+	supportedEnvoyVersion = "standard:1.17.0"
 )
 
 // NewCmd returns a command that generates the initial set of files

--- a/pkg/cmd/extension/init/cmd_test.go
+++ b/pkg/cmd/extension/init/cmd_test.go
@@ -183,7 +183,7 @@ Run 'getenvoy extension init --help' for usage.
 				Expect(descriptor.Name).To(Equal(name))
 				Expect(descriptor.Category.String()).To(Equal(given.category))
 				Expect(descriptor.Language.String()).To(Equal(given.language))
-				Expect(descriptor.Runtime.Envoy.Version).To(Equal("wasm:1.15"))
+				Expect(descriptor.Runtime.Envoy.Version).To(Equal("standard:1.17.0"))
 
 				By("verifying command output")
 				Expect(stdout.String()).To(BeEmpty())

--- a/pkg/cmd/extension/push/testdata/workspace/.getenvoy/extension/extension.yaml
+++ b/pkg/cmd/extension/push/testdata/workspace/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/cmd/extension/run/cmd.go
+++ b/pkg/cmd/extension/run/cmd.go
@@ -144,7 +144,7 @@ Run Envoy extension in the example setup.`,
   getenvoy extension run
 
   # Run Envoy extension in the "default" example setup using a particular Envoy release provided by getenvoy.io
-  getenvoy extension run --envoy-version wasm:1.15
+  getenvoy extension run --envoy-version standard:1.17.0
 
   # Run Envoy extension in the "default" example setup using a custom Envoy binary
   getenvoy extension run --envoy-path /path/to/envoy

--- a/pkg/cmd/extension/run/cmd_test.go
+++ b/pkg/cmd/extension/run/cmd_test.go
@@ -34,6 +34,8 @@ import (
 
 	"github.com/otiai10/copy"
 
+	"github.com/Masterminds/semver"
+
 	"github.com/tetratelabs/getenvoy/pkg/cmd"
 	"github.com/tetratelabs/getenvoy/pkg/manifest"
 	"github.com/tetratelabs/getenvoy/pkg/types"
@@ -132,7 +134,7 @@ var _ = Describe("getenvoy extension run", func() {
 	var manifestServer manifesttest.Server
 
 	BeforeEach(func() {
-		testManifest, err := manifesttest.NewSimpleManifest("wasm:1.15", "wasm:stable")
+		testManifest, err := manifesttest.NewSimpleManifest("standard:1.17.0", "wasm:1.15", "wasm:stable")
 		Expect(err).NotTo(HaveOccurred())
 
 		manifestServer = manifesttest.NewServer(&manifesttest.ServerOpts{
@@ -144,6 +146,12 @@ var _ = Describe("getenvoy extension run", func() {
 				}
 				if ref.Flavor == "wasm" {
 					return envoySubstituteArchiveDir, nil
+				}
+				if ref.Flavor == "standard" {
+					ver, e := semver.NewVersion(ref.Version)
+					if e == nil && ver.Major() >= 1 && ver.Minor() >= 17 {
+						return envoySubstituteArchiveDir, nil
+					}
 				}
 				return "", errors.Errorf("unexpected version of Envoy %q", uri)
 			},
@@ -166,7 +174,7 @@ var _ = Describe("getenvoy extension run", func() {
 	var platform string
 
 	BeforeEach(func() {
-		key, err := manifest.NewKey("wasm:1.15")
+		key, err := manifest.NewKey("standard:1.17.0")
 		Expect(err).NotTo(HaveOccurred())
 		platform = strings.ToLower(key.Platform)
 	})
@@ -290,7 +298,7 @@ Run 'getenvoy extension run --help' for usage.
 
 	It("should not allow --envoy-version and --envoy-path flags at the same time", func() {
 		By("running command")
-		c.SetArgs([]string{"extension", "run", "--envoy-version", "wasm:1.15", "--envoy-path", "envoy"})
+		c.SetArgs([]string{"extension", "run", "--envoy-version", "standard:1.17.0", "--envoy-path", "envoy"})
 		err := cmdutil.Execute(c)
 		Expect(err).To(HaveOccurred())
 
@@ -478,7 +486,7 @@ Run 'getenvoy extension run --help' for usage.
 
 			By("verifying command output")
 			Expect(stdout.String()).To(Equal(fmt.Sprintf(`%s/docker run -u 1001:1002 --rm -t -v %s:/source -w /source --init getenvoy/extension-rust-builder:latest build --output-file target/getenvoy/extension.wasm
-%s/builds/wasm/1.15/%s/bin/envoy -c %s/envoy.tmpl.yaml
+%s/builds/standard/1.17.0/%s/bin/envoy -c %s/envoy.tmpl.yaml
 `, dockerDir, workspaceDir, getenvoyHomeDir, platform, envoyCaptured.cwd())))
 			Expect(stderr.String()).To(Equal("docker stderr\nenvoy stderr\n"))
 
@@ -510,7 +518,7 @@ Run 'getenvoy extension run --help' for usage.
 
 			By("verifying command output")
 			Expect(stdout.String()).To(Equal(fmt.Sprintf(`%s/docker run -u 1001:1002 --rm -t -v %s:/source -w /source --init -e VAR=VALUE -v /host:/container build/image build --output-file target/getenvoy/extension.wasm
-%s/builds/wasm/1.15/%s/bin/envoy -c %s/envoy.tmpl.yaml
+%s/builds/standard/1.17.0/%s/bin/envoy -c %s/envoy.tmpl.yaml
 `, dockerDir, workspaceDir, getenvoyHomeDir, platform, envoyCaptured.cwd())))
 			Expect(stderr.String()).To(Equal("docker stderr\nenvoy stderr\n"))
 		})
@@ -600,7 +608,7 @@ Run 'getenvoy extension run --help' for usage.
 
 			By("verifying command output")
 			Expect(stdout.String()).To(Equal(fmt.Sprintf(`%s/docker run -u 1001:1002 --rm -t -v %s:/source -w /source --init getenvoy/extension-rust-builder:latest build --output-file target/getenvoy/extension.wasm
-%s/builds/wasm/1.15/%s/bin/envoy -c %s/envoy.tmpl.yaml --concurrency 2 --component-log-level wasm:debug,config:trace
+%s/builds/standard/1.17.0/%s/bin/envoy -c %s/envoy.tmpl.yaml --concurrency 2 --component-log-level wasm:debug,config:trace
 `, dockerDir, workspaceDir, getenvoyHomeDir, platform, envoyCaptured.cwd())))
 			Expect(stderr.String()).To(Equal("docker stderr\nenvoy stderr\n"))
 		})
@@ -625,7 +633,7 @@ Run 'getenvoy extension run --help' for usage.
 			Expect(err).NotTo(HaveOccurred())
 
 			By("verifying command output")
-			Expect(stdout.String()).To(Equal(fmt.Sprintf("%s/builds/wasm/1.15/%s/bin/envoy -c %s/envoy.tmpl.yaml\n", getenvoyHomeDir, platform, envoyCaptured.cwd())))
+			Expect(stdout.String()).To(Equal(fmt.Sprintf("%s/builds/standard/1.17.0/%s/bin/envoy -c %s/envoy.tmpl.yaml\n", getenvoyHomeDir, platform, envoyCaptured.cwd())))
 			Expect(stderr.String()).To(Equal("envoy stderr\n"))
 
 			By("verifying Envoy config")
@@ -658,7 +666,7 @@ Run 'getenvoy extension run --help' for usage.
 
 			By("verifying command output")
 			Expect(stdout.String()).To(Equal(fmt.Sprintf(`%s/docker run -u 1001:1002 --rm -t -v %s:/source -w /source --init getenvoy/extension-rust-builder:latest build --output-file target/getenvoy/extension.wasm
-%s/builds/wasm/1.15/%s/bin/envoy -c %s/envoy.tmpl.yaml
+%s/builds/standard/1.17.0/%s/bin/envoy -c %s/envoy.tmpl.yaml
 `, dockerDir, workspaceDir, getenvoyHomeDir, platform, envoyCaptured.cwd())))
 			Expect(stderr.String()).To(Equal("docker stderr\nenvoy stderr\n"))
 
@@ -690,7 +698,7 @@ Run 'getenvoy extension run --help' for usage.
 
 			By("verifying command output")
 			Expect(stdout.String()).To(Equal(fmt.Sprintf(`%s/docker run -u 1001:1002 --rm -t -v %s:/source -w /source --init getenvoy/extension-rust-builder:latest build --output-file target/getenvoy/extension.wasm
-%s/builds/wasm/1.15/%s/bin/envoy -c %s/envoy.tmpl.yaml
+%s/builds/standard/1.17.0/%s/bin/envoy -c %s/envoy.tmpl.yaml
 `, dockerDir, workspaceDir, getenvoyHomeDir, platform, envoyCaptured.cwd())))
 			Expect(stderr.String()).To(Equal(`Scaffolding a new example setup:
 * .getenvoy/extension/examples/default/README.md

--- a/pkg/cmd/extension/run/testdata/workspace/.getenvoy/extension/extension.yaml
+++ b/pkg/cmd/extension/run/testdata/workspace/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ category: envoy.filters.http
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/extension/workspace/config/extension/extension_test.go
+++ b/pkg/extension/workspace/config/extension/extension_test.go
@@ -119,7 +119,7 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0
 `,
 					expectedErr: `extension name cannot be empty`,
 				}),
@@ -137,7 +137,7 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0
 `,
 					expectedErr: `"?!@#$%" is not a valid extension name. Extension name must match the format "^[a-z0-9_]+(\\.[a-z0-9_]+)*$". E.g., 'mycompany.filters.http.custom_metrics'`,
 				}),
@@ -174,7 +174,7 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0
 `,
 				}),
 			)

--- a/pkg/extension/workspace/example/runtime/configdir/testdata/workspace1/.getenvoy/extension/extension.yaml
+++ b/pkg/extension/workspace/example/runtime/configdir/testdata/workspace1/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/extension/workspace/example/runtime/configdir/testdata/workspace2/.getenvoy/extension/extension.yaml
+++ b/pkg/extension/workspace/example/runtime/configdir/testdata/workspace2/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/extension/workspace/example/runtime/configdir/testdata/workspace3/.getenvoy/extension/extension.yaml
+++ b/pkg/extension/workspace/example/runtime/configdir/testdata/workspace3/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/extension/workspace/example/runtime/configdir/testdata/workspace4/.getenvoy/extension/extension.yaml
+++ b/pkg/extension/workspace/example/runtime/configdir/testdata/workspace4/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/extension/workspace/example/runtime/configdir/testdata/workspace5/.getenvoy/extension/extension.yaml
+++ b/pkg/extension/workspace/example/runtime/configdir/testdata/workspace5/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/extension/workspace/example/runtime/configdir/testdata/workspace6/.getenvoy/extension/extension.yaml
+++ b/pkg/extension/workspace/example/runtime/configdir/testdata/workspace6/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/extension/workspace/example/runtime/configdir/testdata/workspace7/.getenvoy/extension/extension.yaml
+++ b/pkg/extension/workspace/example/runtime/configdir/testdata/workspace7/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/extension/workspace/toolchain/builtin/testdata/workspace/.getenvoy/extension/extension.yaml
+++ b/pkg/extension/workspace/toolchain/builtin/testdata/workspace/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/extension/workspace/toolchain/lookup_test.go
+++ b/pkg/extension/workspace/toolchain/lookup_test.go
@@ -90,7 +90,7 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0
 `))
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/extension/workspace/toolchain/testdata/workspace1/.getenvoy/extension/extension.yaml
+++ b/pkg/extension/workspace/toolchain/testdata/workspace1/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/extension/workspace/toolchain/testdata/workspace2/.getenvoy/extension/extension.yaml
+++ b/pkg/extension/workspace/toolchain/testdata/workspace2/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0

--- a/pkg/extension/workspace/toolchain/testdata/workspace3/.getenvoy/extension/extension.yaml
+++ b/pkg/extension/workspace/toolchain/testdata/workspace3/.getenvoy/extension/extension.yaml
@@ -11,4 +11,4 @@ language: rust
 # Runtime the extension is being developed against.
 runtime:
   envoy:
-    version: wasm:1.15
+    version: standard:1.17.0


### PR DESCRIPTION
Wasm plugin has been introduced in Envoy 1.17, so we're working on migrating the GetEnvoy's default Envoy version for Wasm from the `wasm: 1.15` branch to 1.17.
This PR changes the default Envoy version for Wasm templates to `standard:1.17.0`.

This PR depends on tetratelabs/envoy-wasm-rust-sdk#67`. This PR should be merged after it's completed.

