### PR TITLE
Fix builders tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,12 +48,12 @@ jobs:
         fetch-depth: 0
 
     - name: "Get tag name"
-      id: git_tag
-      run: |
-        echo ::set-output name=NAME::${GITHUB_REF/refs\/tags\//}
+      run: | # Trim "v" prefix in the release tag
+        RELEASE_TAG=${GITHUB_REF#refs/*/}
+        echo "BUILDERS_TAG=${RELEASE_TAG:1}" >> $GITHUB_ENV
 
     - name: "Build extension builder images"
-      run: make builders BUILDERS_TAG=${{ steps.git_tag.outputs.NAME }}
+      run: make builders BUILDERS_TAG=${BUILDERS_TAG}
 
     - name: "Login into DockerHub"
       uses: azure/docker-login@v1
@@ -62,7 +62,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - name: "Push extension builder images"
-      run: make builders.push BUILDERS_TAG=${{ steps.git_tag.outputs.NAME }}
+      run: make builders.push BUILDERS_TAG=${BUILDERS_TAG}
 
   e2e_bin:
     name: "Build `e2e` binaries for use in e2e tests"
@@ -97,9 +97,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: "Get tag name"
-      id: git_tag
       run: |
-        echo ::set-output name=NAME::${GITHUB_REF/refs\/tags\//}
+        RELEASE_TAG=${GITHUB_REF#refs/*/}
+        echo "BUILDERS_TAG=${RELEASE_TAG:1}" >> $GITHUB_ENV
 
     - name: "Download `e2e` binary pre-built by the upstream job"
       uses: actions/download-artifact@v2
@@ -119,8 +119,8 @@ jobs:
         tar -C build/bin/linux/amd64 -xf ${INPUT_FILE} getenvoy
 
     - name: "Pull extension builder images"
-      run: make builders.pull BUILDERS_TAG=${{ steps.git_tag.outputs.NAME }} # pull Docker images in advance to make output of
-                                                                             # `getenvoy extension build | test | run` stable
+      run: make builders.pull BUILDERS_TAG=${BUILDERS_TAG} # pull Docker images in advance to make output of
+                                                           # `getenvoy extension build | test | run` stable
 
     - name: "Run e2e tests using released `getenvoy` binary and published extension builder images"
       run: ./ci/e2e/linux/run_tests.sh
@@ -137,9 +137,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: "Get tag name"
-      id: git_tag
-      run: |
-        echo ::set-output name=NAME::${GITHUB_REF/refs\/tags\//}
+      run: | # Trim "v" prefix in the release tag
+        RELEASE_TAG=${GITHUB_REF#refs/*/}
+        echo "BUILDERS_TAG=${RELEASE_TAG:1}" >> $GITHUB_ENV
 
     - name: "Download `e2e` binary pre-built by the upstream job"
       uses: actions/download-artifact@v2
@@ -162,8 +162,8 @@ jobs:
       run: ./ci/e2e/macos/install_docker.sh
 
     - name: "Pull extension builder images"
-      run: make builders.pull BUILDERS_TAG=${{ steps.git_tag.outputs.NAME }} # pull Docker images in advance to make output of
-                                                                             # `getenvoy extension build | test | run` stable
+      run: make builders.pull BUILDERS_TAG=${BUILDERS_TAG} # pull Docker images in advance to make output of
+                                                           # `getenvoy extension build | test | run` stable
 
     - name: "Run e2e tests using released `getenvoy` binary and published extension builder images"
       run: ./ci/e2e/macos/run_tests.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
         echo "BUILDERS_TAG=${RELEASE_TAG:1}" >> $GITHUB_ENV
 
     - name: "Build extension builder images"
-      run: make builders BUILDERS_TAG=${BUILDERS_TAG}
+      run: make builders BUILDERS_TAG=${{ env.BUILDERS_TAG }}
 
     - name: "Login into DockerHub"
       uses: azure/docker-login@v1
@@ -62,7 +62,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - name: "Push extension builder images"
-      run: make builders.push BUILDERS_TAG=${BUILDERS_TAG}
+      run: make builders.push BUILDERS_TAG=${{ env.BUILDERS_TAG }}
 
   e2e_bin:
     name: "Build `e2e` binaries for use in e2e tests"
@@ -119,8 +119,8 @@ jobs:
         tar -C build/bin/linux/amd64 -xf ${INPUT_FILE} getenvoy
 
     - name: "Pull extension builder images"
-      run: make builders.pull BUILDERS_TAG=${BUILDERS_TAG} # pull Docker images in advance to make output of
-                                                           # `getenvoy extension build | test | run` stable
+      run: make builders.pull BUILDERS_TAG=${{ env.BUILDERS_TAG }} # pull Docker images in advance to make output of
+                                                                   # `getenvoy extension build | test | run` stable
 
     - name: "Run e2e tests using released `getenvoy` binary and published extension builder images"
       run: ./ci/e2e/linux/run_tests.sh
@@ -162,8 +162,8 @@ jobs:
       run: ./ci/e2e/macos/install_docker.sh
 
     - name: "Pull extension builder images"
-      run: make builders.pull BUILDERS_TAG=${BUILDERS_TAG} # pull Docker images in advance to make output of
-                                                           # `getenvoy extension build | test | run` stable
+      run: make builders.pull BUILDERS_TAG=${{ env.BUILDERS_TAG }}  # pull Docker images in advance to make output of
+                                                                    # `getenvoy extension build | test | run` stable
 
     - name: "Run e2e tests using released `getenvoy` binary and published extension builder images"
       run: ./ci/e2e/macos/run_tests.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,10 +50,11 @@ jobs:
     - name: "Get tag name"
       run: | # Trim "v" prefix in the release tag
         RELEASE_TAG=${GITHUB_REF#refs/*/}
-        echo "BUILDERS_TAG=${RELEASE_TAG:1}" >> $GITHUB_ENV
+        [[ $RELEASE_TAG = v* ]] && RELEASE_TAG=${RELEASE_TAG:1}
+        echo "RELEASE_VERSION=${RELEASE_TAG}" >> $GITHUB_ENV
 
     - name: "Build extension builder images"
-      run: make builders BUILDERS_TAG=${{ env.BUILDERS_TAG }}
+      run: make builders BUILDERS_TAG=${{ env.RELEASE_VERSION }}
 
     - name: "Login into DockerHub"
       uses: azure/docker-login@v1
@@ -62,7 +63,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - name: "Push extension builder images"
-      run: make builders.push BUILDERS_TAG=${{ env.BUILDERS_TAG }}
+      run: make builders.push BUILDERS_TAG=${{ env.RELEASE_VERSION }}
 
   e2e_bin:
     name: "Build `e2e` binaries for use in e2e tests"
@@ -97,9 +98,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: "Get tag name"
-      run: |
+      run: | # Trim "v" prefix in the release tag
         RELEASE_TAG=${GITHUB_REF#refs/*/}
-        echo "BUILDERS_TAG=${RELEASE_TAG:1}" >> $GITHUB_ENV
+        [[ $RELEASE_TAG = v* ]] && RELEASE_TAG=${RELEASE_TAG:1}
+        echo "RELEASE_VERSION=${RELEASE_TAG}" >> $GITHUB_ENV
 
     - name: "Download `e2e` binary pre-built by the upstream job"
       uses: actions/download-artifact@v2
@@ -119,8 +121,8 @@ jobs:
         tar -C build/bin/linux/amd64 -xf ${INPUT_FILE} getenvoy
 
     - name: "Pull extension builder images"
-      run: make builders.pull BUILDERS_TAG=${{ env.BUILDERS_TAG }} # pull Docker images in advance to make output of
-                                                                   # `getenvoy extension build | test | run` stable
+      run: make builders.pull BUILDERS_TAG=${{ env.RELEASE_VERSION }} # pull Docker images in advance to make output of
+                                                                      # `getenvoy extension build | test | run` stable
 
     - name: "Run e2e tests using released `getenvoy` binary and published extension builder images"
       run: ./ci/e2e/linux/run_tests.sh
@@ -139,7 +141,8 @@ jobs:
     - name: "Get tag name"
       run: | # Trim "v" prefix in the release tag
         RELEASE_TAG=${GITHUB_REF#refs/*/}
-        echo "BUILDERS_TAG=${RELEASE_TAG:1}" >> $GITHUB_ENV
+        [[ $RELEASE_TAG = v* ]] && RELEASE_TAG=${RELEASE_TAG:1}
+        echo "RELEASE_VERSION=${RELEASE_TAG}" >> $GITHUB_ENV
 
     - name: "Download `e2e` binary pre-built by the upstream job"
       uses: actions/download-artifact@v2
@@ -162,8 +165,8 @@ jobs:
       run: ./ci/e2e/macos/install_docker.sh
 
     - name: "Pull extension builder images"
-      run: make builders.pull BUILDERS_TAG=${{ env.BUILDERS_TAG }}  # pull Docker images in advance to make output of
-                                                                    # `getenvoy extension build | test | run` stable
+      run: make builders.pull BUILDERS_TAG=${{ env.RELEASE_VERSION }} # pull Docker images in advance to make output of
+                                                                      # `getenvoy extension build | test | run` stable
 
     - name: "Run e2e tests using released `getenvoy` binary and published extension builder images"
       run: ./ci/e2e/macos/run_tests.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,8 +50,8 @@ jobs:
     - name: "Get tag name"
       run: | # Trim "v" prefix in the release tag
         RELEASE_TAG=${GITHUB_REF#refs/*/}
-        [[ $RELEASE_TAG = v* ]] && RELEASE_TAG=${RELEASE_TAG:1}
-        echo "RELEASE_VERSION=${RELEASE_TAG}" >> $GITHUB_ENV
+        if [[ "${RELEASE_TAG}" = v* ]]; then RELEASE_VERSION="${RELEASE_TAG:1}" else RELEASE_VERSION="${RELEASE_TAG}" fi
+        echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
 
     - name: "Build extension builder images"
       run: make builders BUILDERS_TAG=${{ env.RELEASE_VERSION }}
@@ -100,8 +100,8 @@ jobs:
     - name: "Get tag name"
       run: | # Trim "v" prefix in the release tag
         RELEASE_TAG=${GITHUB_REF#refs/*/}
-        [[ $RELEASE_TAG = v* ]] && RELEASE_TAG=${RELEASE_TAG:1}
-        echo "RELEASE_VERSION=${RELEASE_TAG}" >> $GITHUB_ENV
+        if [[ "${RELEASE_TAG}" = v* ]]; then RELEASE_VERSION="${RELEASE_TAG:1}" else RELEASE_VERSION="${RELEASE_TAG}" fi
+        echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
 
     - name: "Download `e2e` binary pre-built by the upstream job"
       uses: actions/download-artifact@v2
@@ -141,8 +141,8 @@ jobs:
     - name: "Get tag name"
       run: | # Trim "v" prefix in the release tag
         RELEASE_TAG=${GITHUB_REF#refs/*/}
-        [[ $RELEASE_TAG = v* ]] && RELEASE_TAG=${RELEASE_TAG:1}
-        echo "RELEASE_VERSION=${RELEASE_TAG}" >> $GITHUB_ENV
+        if [[ "${RELEASE_TAG}" = v* ]]; then RELEASE_VERSION="${RELEASE_TAG:1}" else RELEASE_VERSION="${RELEASE_TAG}" fi
+        echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
 
     - name: "Download `e2e` binary pre-built by the upstream job"
       uses: actions/download-artifact@v2


### PR DESCRIPTION
Looks like the current release flow pushes builder images with `vx.y.z` which is prefixed by "v'" since `BUILDERS_TAG` is set to be the release tag.

https://github.com/tetratelabs/getenvoy/runs/2110465245?check_suite_focus=true
```
Run make builders.push BUILDERS_TAG=v0.2.1
docker push getenvoy/extension-rust-builder:v0.2.1
....
docker push getenvoy/extension-tinygo-builder:v0.2.1
....
```

And this results in `getenvoy extension {test,build}` failures with image not found:

```
getenvoy extension build
Unable to find image 'getenvoy/extension-rust-builder:0.2.1' locally
docker: Error response from daemon: manifest for getenvoy/extension-rust-builder:0.2.1 not found: manifest unknown: manifest unknown.
See 'docker run --help'.
Error: failed to build Envoy extension using "default" toolchain: failed to execute an external command "/usr/bin/docker run -u 1000:1000 --rm -t -v /home/mathetake/test:/source -w /source --init getenvoy/extension-rust-builder:0.2.1 build --output-file target/getenvoy/extension.wasm": exit status 125

```

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>