### PR TITLE
Fix e2e on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,6 +102,7 @@ jobs:
         RELEASE_TAG=${GITHUB_REF#refs/*/}
         if [[ "${RELEASE_TAG}" = v* ]]; then RELEASE_VERSION="${RELEASE_TAG:1}"; else RELEASE_VERSION="${RELEASE_TAG}"; fi
         echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+        echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
 
     - name: "Download `e2e` binary pre-built by the upstream job"
       uses: actions/download-artifact@v2
@@ -141,6 +142,7 @@ jobs:
         RELEASE_TAG=${GITHUB_REF#refs/*/}
         if [[ "${RELEASE_TAG}" = v* ]]; then RELEASE_VERSION="${RELEASE_TAG:1}"; else RELEASE_VERSION="${RELEASE_TAG}"; fi
         echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
+        echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
 
     - name: "Download `e2e` binary pre-built by the upstream job"
       uses: actions/download-artifact@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,10 +111,8 @@ jobs:
 
     - name: "Download `getenvoy` binary from GithHub release assets"
       env:
-        INPUT_REPO: ${{ github.repository }}
-        INPUT_TOKEN: ${{ secrets.GETENVOY_CI_GITHUB_TOKEN }}
-        INPUT_FILE: getenvoy_${{ steps.git_tag.outputs.NAME }}_Linux_x86_64.tar.gz
-        INPUT_VERSION: tags/${{ steps.git_tag.outputs.NAME }}
+        INPUT_FILE: getenvoy_${{ env.RELEASE_VERSION }}_Linux_x86_64.tar.gz
+        INPUT_VERSION: tags/${{ env.RELEASE_TAG }}
       run: |
         curl -s https://raw.githubusercontent.com/dsaltares/fetch-gh-release-asset/0.0.5/fetch_github_asset.sh | bash
         mkdir -p build/bin/linux/amd64
@@ -152,10 +150,8 @@ jobs:
 
     - name: "Download `getenvoy` binary from GithHub release assets"
       env:
-        INPUT_REPO: ${{ github.repository }}
-        INPUT_TOKEN: ${{ secrets.GETENVOY_CI_GITHUB_TOKEN }}
-        INPUT_FILE: getenvoy_${{ steps.git_tag.outputs.NAME }}_Darwin_x86_64.tar.gz
-        INPUT_VERSION: tags/${{ steps.git_tag.outputs.NAME }}
+        INPUT_FILE: getenvoy_${{ env.RELEASE_VERSION }}_Darwin_x86_64.tar.gz
+        INPUT_VERSION: tags/${{ env.RELEASE_TAG }}
       run: |
         curl -s https://raw.githubusercontent.com/dsaltares/fetch-gh-release-asset/0.0.5/fetch_github_asset.sh | bash
         mkdir -p build/bin/darwin/amd64


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>


Fix the failure in e2e in release pipeline: https://github.com/tetratelabs/getenvoy/runs/2110493412?check_suite_focus=true
```
Run curl -s https://raw.githubusercontent.com/dsaltares/fetch-gh-release-asset/0.0.5/fetch_github_asset.sh | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  9953  100  9953    0     0  99530      0 --:--:-- --:--:-- --:--:-- 99530
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   120  100   120    0     0   1714      0 --:--:-- --:--:-- --:--:--  1714
tar: This does not look like a tar archive

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

Already tested manually on my local machine. 