### PR TITLE
ci: add timeouts to GHA jobs and steps to avoid e2e tests holding MacOS environment for 6 hours

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -14,6 +14,7 @@ jobs:
   bin:
     name: "Build `getenvoy` and `e2e` binaries for use in e2e tests"
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # instead of 360 by default
     steps:
     - name: "Checkout"
       uses: actions/checkout@v2
@@ -40,6 +41,7 @@ jobs:
     needs:
     - bin
     runs-on: ubuntu-latest
+    timeout-minutes: 30 # instead of 360 by default
     steps:
     - name: "Checkout"
       uses: actions/checkout@v2
@@ -61,6 +63,7 @@ jobs:
     needs:
     - bin
     runs-on: macos-latest
+    timeout-minutes: 90 # instead of 360 by default
     steps:
     - name: "Checkout"
       uses: actions/checkout@v2
@@ -73,6 +76,7 @@ jobs:
 
     - name: "Install 'Docker for Mac' (an older version that can be installed in CI environment)"
       run: ./ci/e2e/macos/install_docker.sh
+      timeout-minutes: 10 # unfortunately, installing `Docker for Mac` in CI environment is fragile; be ready to restart the job ocasionally
 
     - name: "Build language-specific Docker build images"
       env:

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -76,7 +76,7 @@ jobs:
 
     - name: "Install 'Docker for Mac' (an older version that can be installed in CI environment)"
       run: ./ci/e2e/macos/install_docker.sh
-      timeout-minutes: 10 # unfortunately, installing `Docker for Mac` in CI environment is fragile; be ready to restart the job ocasionally
+      timeout-minutes: 7 # unfortunately, installing `Docker for Mac` in CI environment is fragile; be ready to restart the job ocasionally
 
     - name: "Build language-specific Docker build images"
       env:

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -84,6 +84,7 @@ jobs:
         # options when using `Docker for Mac` in CI environment
         USE_DOCKER_BUILDKIT_CACHE: 'no'
       run: make builders
+      timeout-minutes: 10 # fail fast if MacOS runner becomes to slow
 
     - name: "Run e2e tests using `getenvoy` and `e2e` binaries built by the upstream job"
       run: ./ci/e2e/macos/run_tests.sh

--- a/ci/e2e/macos/install_docker.sh
+++ b/ci/e2e/macos/install_docker.sh
@@ -35,7 +35,7 @@ nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended > /dev/stdout 
 while ! docker info 2> /dev/null; do
 	sleep 5
 	echo "Waiting for docker service to be in the running state. \
-	If Docker is not ready within 10 minutes, it's better to fail the current CI Job and let a comitter to start it again manually"
+	If Docker is not ready within 10 minutes, it's better to fail the current CI Job and let the comitter to re-start the job manually"
 done
 
 # sanity check

--- a/ci/e2e/macos/install_docker.sh
+++ b/ci/e2e/macos/install_docker.sh
@@ -34,7 +34,8 @@ sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unatt
 nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended > /dev/stdout &
 while ! docker info 2> /dev/null; do
 	sleep 5
-	echo "Waiting for docker service to be in the running state"
+	echo "Waiting for docker service to be in the running state. \
+	If Docker is not ready within 10 minutes, it's better to fail the current CI Job and let a comitter to start it again manually"
 done
 
 # sanity check


### PR DESCRIPTION
Signed-off-by: Yaroslav Skopets <yaroslav@tetrate.io>

## Summary

* this PR sets deadlines for `e2e` test jobs on `Mac` to avoid wasting resources for `6 hours` when `Docker for Mac` fails to install correctly

## Implementation notes

* This PR is based on `master` prior to #135 
* This PR only makes sense if #135  is reverted from `master`
* If this PR is merged on `master` without reverting #135, it will cause all builds to fail (because they take `3,5+ hours` and this PR is trying to prevent that)