### PR TITLE
Reverts to old macos install_docker.sh

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -20,6 +20,7 @@ jobs:
   bin:
     name: "Build `getenvoy` and `e2e` binaries for use in e2e tests"
     runs-on: ubuntu-latest
+    timeout-minutes: 15  # instead of 360 by default
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -46,6 +47,7 @@ jobs:
     needs:
       - bin
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # instead of 360 by default
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -67,6 +69,7 @@ jobs:
     needs:
       - bin
     runs-on: macos-latest
+    timeout-minutes: 90  # instead of 360 by default
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -79,6 +82,7 @@ jobs:
 
       - name: "Install 'Docker for Mac' (an older version that can be installed in CI environment)"
         run: ./ci/e2e/macos/install_docker.sh
+        timeout-minutes: 7  # unfortunately, installing `Docker for Mac` in CI environment is fragile; be ready to restart the job occasionally
 
       - name: "Build language-specific Docker build images"
         env:
@@ -86,6 +90,7 @@ jobs:
           # options when using `Docker for Mac` in CI environment
           USE_DOCKER_BUILDKIT_CACHE: 'no'
         run: make builders
+        timeout-minutes: 10  # fail fast if MacOS runner becomes to slow
 
       - name: "Run e2e tests using `getenvoy` and `e2e` binaries built by the upstream job"
         run: ./ci/e2e/macos/run_tests.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,6 +99,7 @@ jobs:
       - builders
       - e2e_bin
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # instead of 360 by default
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -139,6 +140,7 @@ jobs:
       - builders
       - e2e_bin
     runs-on: macos-latest
+    timeout-minutes: 90  # instead of 360 by default
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -167,11 +169,13 @@ jobs:
 
       - name: "Install 'Docker for Mac' (an older version that can be installed in CI environment)"
         run: ./ci/e2e/macos/install_docker.sh
+        timeout-minutes: 7  # unfortunately, installing `Docker for Mac` in CI environment is fragile; be ready to restart the job ocasionally
 
       - name: "Pull extension builder images"
         # pull Docker images in advance to make output of
         # `getenvoy extension build | test | run` stable
         run: make builders.pull BUILDERS_TAG=${{ env.RELEASE_VERSION }}
+        timeout-minutes: 10  # fail fast if MacOS runner becomes to slow
 
       - name: "Run e2e tests using released `getenvoy` binary and published extension builder images"
         run: ./ci/e2e/macos/run_tests.sh

--- a/ci/e2e/macos/.licenserignore
+++ b/ci/e2e/macos/.licenserignore
@@ -1,3 +1,0 @@
-# install_docker.sh a copy of https://github.com/play-with-go/play-with-go/blob/d2a13db0ed4ac80b39ce727cd54f2438c93096dc/_scripts/macCISetup.sh
-# Copyright (c) 2020, The play-with-go.dev Authors. All rights reserved. BSD-3-Clause License
-install_docker.sh

--- a/ci/e2e/macos/install_docker.sh
+++ b/ci/e2e/macos/install_docker.sh
@@ -1,61 +1,41 @@
 #!/usr/bin/env bash
 
-# Below is a copy of https://github.com/play-with-go/play-with-go/blob/d2a13db0ed4ac80b39ce727cd54f2438c93096dc/_scripts/macCISetup.sh
-# The last change to this file was in response to this comment https://github.com/docker/for-mac/issues/2359#issuecomment-793595407
+# Copyright 2020 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-set -euo pipefail
+set -e
 
-# We can't have this line because the default version of bash on mac os too old
-# shopt -s inherit_errexit
+TMP_DIR=$(mktemp -d)
 
-# With thanks/credit to https://github.com/docker/for-mac/issues/2359#issuecomment-607154849
+# Docker for Mac 2.0.0.3-ce-mac81,31259 (the last version of 'Docker for Mac' that can be installed in CI environment)
+E2E_MACOS_DOCKER_CASK_VERSION="${E2E_MACOS_DOCKER_CASK_VERSION:-8ce4e89d10716666743b28c5a46cd54af59a9cc2}"
 
-# Update brew to make sure we're using the latest formulae
-brew update
+# install Docker for Mac
+pushd "${TMP_DIR}"
+curl -L https://raw.githubusercontent.com/Homebrew/homebrew-cask/${E2E_MACOS_DOCKER_CASK_VERSION}/Casks/docker.rb > docker.rb
+brew install --cask docker.rb
+popd
 
-###############################
-# General
-brew install bash
-brew install gsed
-brew install findutils
-ln -s /usr/local/bin/gsed /usr/local/bin/sed
-ln -s /usr/local/bin/gfind /usr/local/bin/find
-hash -r
-which sed
-which find
-
-###############################
-# Docker
-
-# Install Docker
-brew install --cask docker
-
-# Allow the app to run without confirmation
-xattr -d -r com.apple.quarantine /Applications/Docker.app
-
-# preemptively do docker.app's setup to avoid any gui prompts
-sudo /bin/cp /Applications/Docker.app/Contents/Library/LaunchServices/com.docker.vmnetd /Library/PrivilegedHelperTools
-sudo /bin/cp /Applications/Docker.app/Contents/Resources/com.docker.vmnetd.plist /Library/LaunchDaemons/
-sudo /bin/chmod 544 /Library/PrivilegedHelperTools/com.docker.vmnetd
-sudo /bin/chmod 644 /Library/LaunchDaemons/com.docker.vmnetd.plist
-sudo /bin/launchctl load /Library/LaunchDaemons/com.docker.vmnetd.plist
-
-# Run
-[[ $(uname) == 'Darwin' ]] || {
-	echo "This function only runs on macOS." >&2
-	exit 2
-}
-
-echo "-- Starting Docker.app, if necessary..."
-
-open -g -a /Applications/Docker.app || exit
-
-# Wait for the server to start up, if applicable.
-i=0
-while ! docker system info &> /dev/null; do
-	((i++ == 0)) && printf %s '-- Waiting for Docker to finish starting up...' || printf '.'
-	sleep 1
+# follow instructions from:
+#   https://github.com/microsoft/azure-pipelines-image-generation/issues/738#issuecomment-496211237
+#   https://github.com/microsoft/azure-pipelines-image-generation/issues/738#issuecomment-522301481
+sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended
+nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended > /dev/stdout &
+while ! docker info 2> /dev/null; do
+	sleep 5
+	echo "Waiting for docker service to be in the running state"
 done
-((i))   && printf '\n'
 
-echo "-- Docker is ready."
+# sanity check
+docker run --rm -t busybox date

--- a/ci/e2e/macos/install_docker.sh
+++ b/ci/e2e/macos/install_docker.sh
@@ -34,7 +34,8 @@ sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unatt
 nohup /Applications/Docker.app/Contents/MacOS/Docker --unattended > /dev/stdout &
 while ! docker info 2> /dev/null; do
 	sleep 5
-	echo "Waiting for docker service to be in the running state"
+	echo "Waiting for docker service to be in the running state. \
+	If Docker is not ready within 10 minutes, it's better to fail the current CI Job and let the comitter to re-start the job manually"
 done
 
 # sanity check


### PR DESCRIPTION
The old script that was failing to install and swapped out in #135 works again. This reverts it until we can diagnose what's behind the hanging in #145, or something else fixes it.

Fixes #140