### PR TITLE
Fixes bug where fully resolved image ref wasn't used

### DIFF
--- a/pkg/cmd/extension/push/cmd.go
+++ b/pkg/cmd/extension/push/cmd.go
@@ -108,7 +108,7 @@ Push the built WASM extension to the OCI-compliant registry. This command requir
 			if err != nil {
 				return fmt.Errorf("failed to push the wasm image: %w", err)
 			}
-			manifest, size, err := pusher.Push(imagePath, imageRef)
+			manifest, size, err := pusher.Push(imagePath, ref.String())
 			if err != nil {
 				return fmt.Errorf("failed to push the wasm image: %w", err)
 			}


### PR DESCRIPTION
Recent docker tools require fully resolved image tags (ex :latest
explicitly). While we ensured the latest tag was appended, we didn't use
it. I noticed this pushing to my local registry on latest OS/x and Docker.