### PR TITLE
Normalizes Reference.Platform to lower-hyphen format

### DIFF
--- a/pkg/binary/envoy/fetch.go
+++ b/pkg/binary/envoy/fetch.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/mholt/archiver"
 	"github.com/schollz/progressbar/v2"
@@ -87,9 +86,7 @@ func (r *Runtime) BinaryStore() string {
 }
 
 func (r *Runtime) platformDirectory(key *manifest.Key) string {
-	platform := strings.ToLower(key.Platform)
-	platform = strings.ReplaceAll(platform, "-", "_")
-	return filepath.Join(r.BinaryStore(), key.Flavor, key.Version, platform)
+	return filepath.Join(r.BinaryStore(), key.Flavor, key.Version, key.Platform)
 }
 
 func fetchEnvoy(dst, src string) error {

--- a/pkg/manifest/locate_test.go
+++ b/pkg/manifest/locate_test.go
@@ -120,12 +120,12 @@ func TestNewKey(t *testing.T) {
 		wantErr   bool
 	}{
 		{"flavor:version/platform/platform", nil, true},
-		{"flavor:version/platform", &Key{Flavor: "flavor", Version: "version", Platform: "PLATFORM"}, false},
-		{"flavor:version/platform-glibc", &Key{Flavor: "flavor", Version: "version", Platform: "PLATFORM_GLIBC"}, false},
-		{"fLaVoR:VeRsIoN/pLaTfOrM", &Key{Flavor: "flavor", Version: "version", Platform: "PLATFORM"}, false},
-		{"flavor:version/", &Key{Flavor: "flavor", Version: "version", Platform: platformToEnum(platform())}, false},
-		{"flavor:version", &Key{Flavor: "flavor", Version: "version", Platform: platformToEnum(platform())}, false},
-		{"fLaVoR:VeRsIoN", &Key{Flavor: "flavor", Version: "version", Platform: platformToEnum(platform())}, false},
+		{"flavor:version/DARWIN", &Key{Flavor: "flavor", Version: "version", Platform: "darwin"}, false},
+		{"flavor:version/PLATFORM_GLIBC", &Key{Flavor: "flavor", Version: "version", Platform: "platform-glibc"}, false},
+		{"fLaVoR:VeRsIoN/pLaTfOrM", &Key{Flavor: "flavor", Version: "version", Platform: "platform"}, false},
+		{"flavor:version/", &Key{Flavor: "flavor", Version: "version", Platform: platform()}, false},
+		{"flavor:version", &Key{Flavor: "flavor", Version: "version", Platform: platform()}, false},
+		{"fLaVoR:VeRsIoN", &Key{Flavor: "flavor", Version: "version", Platform: platform()}, false},
 		{"flavor:", nil, true},
 		{"flavor", nil, true},
 	}

--- a/pkg/manifest/print.go
+++ b/pkg/manifest/print.go
@@ -19,13 +19,13 @@ import (
 	"io"
 	"net/http"
 	"sort"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/golang/protobuf/jsonpb"
 
 	"github.com/tetratelabs/getenvoy-package/api"
 	"github.com/tetratelabs/getenvoy/pkg/transport"
+	"github.com/tetratelabs/getenvoy/pkg/types"
 )
 
 // Print retrieves the manifest from the passed location and writes it to the passed writer
@@ -40,18 +40,12 @@ func Print(writer io.Writer) error {
 	for _, flavor := range deterministicFlavors(manifest.Flavors) {
 		for _, version := range deterministicVersions(flavor.Versions) {
 			for _, build := range deterministicBuilds(version.Builds) {
-				ref := fmt.Sprintf("%v:%v/%v", flavor.Name, version.Name, platformFromEnum(build.Platform.String()))
+				ref := fmt.Sprintf("%v:%v/%v", flavor.Name, version.Name, types.PlatformFromEnum(build.Platform.String()))
 				fmt.Fprintf(w, "%v\t%v\t%v\n", ref, flavor.Name, version.Name)
 			}
 		}
 	}
 	return w.Flush()
-}
-
-func platformFromEnum(s string) string {
-	s = strings.ToLower(s)
-	s = strings.ReplaceAll(s, "_", "-")
-	return s
 }
 
 func fetch(url string) (*api.Manifest, error) {

--- a/pkg/types/reference.go
+++ b/pkg/types/reference.go
@@ -24,9 +24,17 @@ import (
 
 // Reference identifies an Envoy release provided by getenvoy.io.
 type Reference struct {
-	Flavor   string
-	Version  string
+	Flavor  string
+	Version string
+	// Platform is an lower-hyphen representation of the platform. Ex. "darwin" or "linux-glibc"
 	Platform string
+}
+
+// PlatformFromEnum takes a Reference.Platform like "LINUX_GLIBC" and returns a string variant like "linux-glibc"
+func PlatformFromEnum(s string) string {
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, "_", "-")
+	return s
 }
 
 var (
@@ -39,7 +47,7 @@ func ParseReference(text string) (*Reference, error) {
 	if len(matches) != 4 {
 		return nil, errors.Errorf("%q is not a valid GetEnvoy reference. Expected format: <flavor>:<version>[/<platform>]", text)
 	}
-	return &Reference{strings.ToLower(matches[1]), strings.ToLower(matches[2]), strings.ToLower(matches[3])}, nil
+	return &Reference{strings.ToLower(matches[1]), strings.ToLower(matches[2]), PlatformFromEnum(matches[3])}, nil
 }
 
 func (r *Reference) String() string {


### PR DESCRIPTION
Before, we mixed format of `Reference.Platform` to sometimes enum and
other times lower-hyphen format. This is confusing and leads to subtle
bugs. For example, some code did simply a lowercase and forgot to
convert underscores to hyphens.

This change normalizes to always write lower-hypen.

This also fixes a couple tests which panic'ed due to #137, but were
otherwise unrelated.