### PR TITLE
Uses alternative source for busybox image in osx script

### DIFF
--- a/ci/e2e/macos/install_docker.sh
+++ b/ci/e2e/macos/install_docker.sh
@@ -38,5 +38,5 @@ while ! docker info 2> /dev/null; do
 	If Docker is not ready within 10 minutes, it's better to fail the current CI Job and let the comitter to re-start the job manually"
 done
 
-# sanity check
-docker run --rm -t busybox date
+# sanity check without using docker.io as it is rate-limited
+docker run --rm quay.io/prometheus/busybox date


### PR DESCRIPTION
The one we used before relies on docker.io which is rate-limited.

See #149

Signed-off-by: Adrian Cole <adrian@tetrate.io>