### PR TITLE
Execute chmod for TinyGo gocache on trap

### DIFF
--- a/images/extension-builders/tinygo/commands.sh
+++ b/images/extension-builders/tinygo/commands.sh
@@ -16,19 +16,21 @@
 set -ue
 
 extension_build()  {
+	set_trap
 	tinygo build -o "$1" -scheduler=none -target wasi main.go
-	# This is necessary since the created go caches are with read-only permission,
-	# and without this, the host user cannot delete the build directory with "rm -rf".
-	chmod -R u+rw "${GOMODCACHE}"
 }
 
 extension_test()  {
+	set_trap
 	go test -tags=proxytest -v ./...
-	# This is necessary since the created go caches are with read-only permission,
-	# and without this, the host user cannot delete the build directory with "rm -rf".
-	chmod -R u+rw "${GOMODCACHE}"
 }
 
 extension_clean()  {
 	rm -rf build
+}
+
+set_trap() {
+	# This is necessary since the created go caches are with read-only permission,
+	# and without this, the host user cannot delete the build directory with "rm -rf".
+	trap "chmod -R u+rw ${GOMODCACHE}" EXIT ERR INT TERM
 }


### PR DESCRIPTION
Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>

Previously, when `go {test,build}` fails, chmod would never be called. That would cause the nasty permission denied error when test/build failures occur during e2e as well as users try to remove an extension dir after failure.