### PR TITLE
Cleans signal handling and reduces complexity of "getenvoy run"

### DIFF
--- a/pkg/binary/envoy/controlplane/istio_test.go
+++ b/pkg/binary/envoy/controlplane/istio_test.go
@@ -60,7 +60,7 @@ func TestEnableIstioBootstrap(t *testing.T) {
 		func(r *envoy.Runtime) {
 			r.Config.Mode = envoy.ParseMode("loadbalancer")
 			// Choosing a random port doesn't help because envoy_bootstrap.json hard-codes 15020 15021 and 15090
-			// See https://github.com/istio/istio/issues/32184 for follow-up
+			// See https://github.com/istio/istio/issues/31138
 			r.Config.AdminPort = 15000
 			r.Config.XDSAddress = pilotGrpc
 			r.Config.IPAddresses = []string{"127.0.0.1"} // prevent calling controlplane.retrieveIPs() on CI hosts
@@ -72,8 +72,7 @@ func TestEnableIstioBootstrap(t *testing.T) {
 	defer os.RemoveAll(runtime.DebugStore())
 
 	envoytest.RequireRunTerminate(t, runtime, envoytest.RunKillOptions{
-		DisableAutoAdminPort: true,
-		RetainDebugStore:     true, // Assertions below inspect files in the debug store
+		DisableAutoAdminPort: true, // Istio uses fixed ports https://github.com/istio/istio/issues/31138
 	})
 
 	serverInfo, err := os.ReadFile(filepath.Join(runtime.DebugStore(), "server_info.json"))

--- a/pkg/binary/envoy/debug/admin_test.go
+++ b/pkg/binary/envoy/debug/admin_test.go
@@ -35,8 +35,7 @@ func TestEnableEnvoyAdminDataCollection(t *testing.T) {
 	defer os.RemoveAll(r.DebugStore())
 
 	envoytest.RequireRunTerminate(t, r, envoytest.RunKillOptions{
-		Bootstrap:        "testdata/admin.yaml", // we need services defined in order to check adminAPIPaths
-		RetainDebugStore: true,                  // Assertions below inspect files in the debug store
+		Bootstrap: "testdata/admin.yaml", // we need services defined in order to check adminAPIPaths
 	})
 
 	for _, filename := range adminAPIPaths {

--- a/pkg/binary/envoy/debug/log_test.go
+++ b/pkg/binary/envoy/debug/log_test.go
@@ -30,9 +30,7 @@ func TestEnableEnvoyLogCollection(t *testing.T) {
 	require.NoError(t, err, "error getting envoy runtime")
 	defer os.RemoveAll(r.DebugStore())
 
-	envoytest.RequireRunTerminate(t, r, envoytest.RunKillOptions{
-		RetainDebugStore: false, // We don't need to unarchive the tar.gz because access logs hold the DebugStore open.
-	})
+	envoytest.RequireRunTerminate(t, r, envoytest.RunKillOptions{})
 
 	// We expect to see logs because when envoy starts up, the status checker will make HTTP requests to /ready
 	for _, filename := range []string{"logs/access.log", "logs/error.log"} {

--- a/pkg/binary/envoy/debug/lsof_test.go
+++ b/pkg/binary/envoy/debug/lsof_test.go
@@ -32,9 +32,7 @@ func TestEnableOpenFilesDataCollection(t *testing.T) {
 	require.NoError(t, err, "error getting envoy runtime")
 	defer os.RemoveAll(r.DebugStore())
 
-	envoytest.RequireRunTerminate(t, r, envoytest.RunKillOptions{
-		RetainDebugStore: true, // Assertions below inspect files in the debug store
-	})
+	envoytest.RequireRunTerminate(t, r, envoytest.RunKillOptions{})
 
 	file := "lsof/lsof.json"
 	path := filepath.Join(r.DebugStore(), file)

--- a/pkg/binary/envoy/debug/node_test.go
+++ b/pkg/binary/envoy/debug/node_test.go
@@ -32,9 +32,7 @@ func TestEnableNodeCollection(t *testing.T) {
 	require.NoError(t, err, "error creating envoy runtime")
 	defer os.RemoveAll(r.DebugStore())
 
-	envoytest.RequireRunTerminate(t, r, envoytest.RunKillOptions{
-		RetainDebugStore: true, // Assertions below inspect files in the debug store
-	})
+	envoytest.RequireRunTerminate(t, r, envoytest.RunKillOptions{})
 
 	files := [...]string{"node/ps.txt", "node/network_interface.json", "node/connections.json"}
 	for _, file := range files {

--- a/pkg/binary/envoy/termination.go
+++ b/pkg/binary/envoy/termination.go
@@ -49,7 +49,7 @@ func interrupt(p *os.Process) {
 func (r *Runtime) handlePostTermination() error {
 	for _, f := range r.postTermination {
 		if err := f(r); err != nil {
-			log.Error(err.Error())
+			log.Errorf("failed to handle post termination: %v",  err)
 		}
 	}
 

--- a/pkg/binary/envoy/termination.go
+++ b/pkg/binary/envoy/termination.go
@@ -49,7 +49,7 @@ func interrupt(p *os.Process) {
 func (r *Runtime) handlePostTermination() error {
 	for _, f := range r.postTermination {
 		if err := f(r); err != nil {
-			log.Errorf("failed to handle post termination: %v",  err)
+			log.Errorf("failed to handle post termination: %v", err)
 		}
 	}
 

--- a/pkg/binary/envoy/termination.go
+++ b/pkg/binary/envoy/termination.go
@@ -15,26 +15,22 @@
 package envoy
 
 import (
+	"fmt"
+	"os"
 	"syscall"
 
+	"github.com/mholt/archiver/v3"
 	"github.com/tetratelabs/log"
 
 	"github.com/tetratelabs/getenvoy/pkg/binary"
 )
 
 func (r *Runtime) handleTermination() {
-	if r.cmd.Process == nil {
-		return // Envoy hasn't started at all
-	}
-	if r.cmd.ProcessState != nil {
-		if r.cmd.ProcessState.Success() {
-			log.Infof("Envoy process (PID=%d) exited successfully", r.cmd.Process.Pid)
-			return
-		}
-		log.Infof("Envoy process (PID=%d) terminated prematurely", r.cmd.Process.Pid)
-		return
-	}
+	cmd := r.cmd
 
+	defer interrupt(cmd.Process) // Ensure the SIGINT forwards to Envoy even if a pre-termination hook panics
+
+	log.Infof("GetEnvoy process (PID=%d) received SIGINT", os.Getpid())
 	// Execute all registered preTermination functions
 	for _, f := range r.preTermination {
 		if err := f(r); err != nil {
@@ -42,13 +38,36 @@ func (r *Runtime) handleTermination() {
 		}
 	}
 
-	// Forward on the SIGINT to Envoy
-	log.Infof("Sending Envoy process (PID=%d) SIGINT", r.cmd.Process.Pid)
-	r.cmd.Process.Signal(syscall.SIGINT) //nolint
+	interrupt(cmd.Process)
+}
+
+func interrupt(p *os.Process) {
+	log.Infof("Sending Envoy process (PID=%d) SIGINT", p.Pid)
+	_ = p.Signal(syscall.SIGINT)
+}
+
+func (r *Runtime) handlePostTermination() error {
+	for _, f := range r.postTermination {
+		if err := f(r); err != nil {
+			log.Error(err.Error())
+		}
+	}
+
+	// Tar up the debug data and clean up
+	if err := archiver.Archive([]string{r.DebugStore()}, r.DebugStore()+".tar.gz"); err != nil {
+		return fmt.Errorf("unable to archive debug store directory %v: %v", r.DebugStore(), err)
+	}
+	return os.RemoveAll(r.DebugStore())
 }
 
 // RegisterPreTermination registers the passed functions to be run after Envoy has started
 // and just before GetEnvoy instructs Envoy to terminate
 func (r *Runtime) RegisterPreTermination(f ...func(binary.Runner) error) {
 	r.preTermination = append(r.preTermination, f...)
+}
+
+// RegisterPostTermination registers the passed functions to be run after Envoy has terminated
+// and just before GetEnvoy archives the debug directory.
+func (r *Runtime) RegisterPostTermination(f ...func(binary.Runner) error) {
+	r.postTermination = append(r.postTermination, f...)
 }

--- a/pkg/binary/envoytest/util.go
+++ b/pkg/binary/envoytest/util.go
@@ -144,6 +144,7 @@ func RequireRunTerminate(t *testing.T, r binary.Runner, options RunKillOptions) 
 
 	// Now, terminate the server.
 	r.FakeInterrupt()
+	deferredInterrupt = nil
 
 	select { // Await run completion
 	case <-time.After(10 * time.Second):

--- a/pkg/binary/interface.go
+++ b/pkg/binary/interface.go
@@ -16,7 +16,6 @@ package binary
 
 import (
 	"io"
-	"os"
 
 	"github.com/tetratelabs/getenvoy/pkg/manifest"
 )
@@ -27,9 +26,8 @@ type Runner interface {
 	RunPath(path string, args []string) error
 	RegisterPreStart(f ...func(Runner) error)
 	RegisterPreTermination(f ...func(Runner) error)
-	RegisterWait(int)
-	RegisterDone()
-	SendSignal(signal os.Signal)
+	RegisterPostTermination(f ...func(Runner) error)
+	FakeInterrupt()
 	Status() int
 	GetPid() (int, error)
 	AppendArgs([]string)


### PR DESCRIPTION
Before, we had complex signal handling in both "getenvoy run" and also
normal command invocation. This solves the first part by reducing the
amount of gears used to run the process, and also moving to
NotifyContext for signal interception.

See #172 for more information on NotifyContext, though this change
doesn't remove the osutil functions, yet. That will be a different PR
as it is a different branch of code.