### PR TITLE
Makes rust examples use a smaller dependency for json

### DIFF
--- a/data/extension/init/templates/rust/envoy.access_loggers/default/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.access_loggers/default/Cargo.toml
@@ -17,5 +17,4 @@ crate-type = ["rlib"]
 
 [dependencies]
 envoy = { package = "envoy-sdk", version = "^0.2.0-alpha.1" }
-serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
+nanoserde = "^0.1.25" # significantly faster to compile than serde

--- a/data/extension/init/templates/rust/envoy.access_loggers/default/src/config.rs
+++ b/data/extension/init/templates/rust/envoy.access_loggers/default/src/config.rs
@@ -1,17 +1,18 @@
 use std::convert::TryFrom;
 
-use serde::Deserialize;
+use nanoserde::DeJson;
 
 use envoy::extension;
 
 /// Configuration for a Sample Access Logger.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, DeJson)]
 pub struct SampleAccessLoggerConfig {}
 
 impl TryFrom<&[u8]> for SampleAccessLoggerConfig {
     type Error = extension::Error;
 
     fn try_from(value: &[u8]) -> extension::Result<Self> {
-        serde_json::from_slice(value).map_err(extension::Error::from)
+        let json = String::from_utf8(value.to_vec())?;
+        DeJson::deserialize_json(&json).map_err(extension::Error::from)
     }
 }

--- a/data/extension/init/templates/rust/envoy.filters.http/default/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.filters.http/default/Cargo.toml
@@ -17,5 +17,4 @@ crate-type = ["rlib"]
 
 [dependencies]
 envoy = { package = "envoy-sdk", version = "^0.2.0-alpha.1" }
-serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
+nanoserde = "^0.1.25" # significantly faster to compile than serde

--- a/data/extension/init/templates/rust/envoy.filters.http/default/src/config.rs
+++ b/data/extension/init/templates/rust/envoy.filters.http/default/src/config.rs
@@ -1,11 +1,11 @@
 use std::convert::TryFrom;
 
-use serde::Deserialize;
+use nanoserde::DeJson;
 
 use envoy::extension;
 
 /// Configuration for a Sample HTTP Filter.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, DeJson)]
 pub struct SampleHttpFilterConfig {}
 
 impl TryFrom<&[u8]> for SampleHttpFilterConfig {
@@ -13,6 +13,7 @@ impl TryFrom<&[u8]> for SampleHttpFilterConfig {
 
     /// Parses filter configuration from JSON.
     fn try_from(value: &[u8]) -> extension::Result<Self> {
-        serde_json::from_slice(value).map_err(Self::Error::from)
+        let json = String::from_utf8(value.to_vec())?;
+        DeJson::deserialize_json(&json).map_err(extension::Error::from)
     }
 }

--- a/data/extension/init/templates/rust/envoy.filters.network/default/Cargo.toml
+++ b/data/extension/init/templates/rust/envoy.filters.network/default/Cargo.toml
@@ -17,5 +17,4 @@ crate-type = ["rlib"]
 
 [dependencies]
 envoy = { package = "envoy-sdk", version = "^0.2.0-alpha.1" }
-serde = { version = "^1.0", features = ["derive"] }
-serde_json = "^1.0"
+nanoserde = "^0.1.25" # significantly faster to compile than serde

--- a/data/extension/init/templates/rust/envoy.filters.network/default/src/config.rs
+++ b/data/extension/init/templates/rust/envoy.filters.network/default/src/config.rs
@@ -1,11 +1,11 @@
 use std::convert::TryFrom;
 
-use serde::Deserialize;
+use nanoserde::DeJson;
 
 use envoy::extension;
 
 /// Configuration for a Sample Network Filter.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, DeJson)]
 pub struct SampleNetworkFilterConfig {}
 
 impl TryFrom<&[u8]> for SampleNetworkFilterConfig {
@@ -13,6 +13,7 @@ impl TryFrom<&[u8]> for SampleNetworkFilterConfig {
 
     /// Parses filter configuration from JSON.
     fn try_from(value: &[u8]) -> extension::Result<Self> {
-        serde_json::from_slice(value).map_err(extension::Error::from)
+        let json = String::from_utf8(value.to_vec())?;
+        DeJson::deserialize_json(&json).map_err(extension::Error::from)
     }
 }


### PR DESCRIPTION
Before, we had a significantly larger dependency tree than needed for
deserializing json:

```
envoy-sample-access-logger-module v0.1.0 (/Users/adrian/tetratelabs/getenvoy/data/extension/init/templates/rust/envoy.access_loggers/default/wasm/module)
├── envoy-sample-access-logger v0.1.0 (/Users/adrian/tetratelabs/getenvoy/data/extension/init/templates/rust/envoy.access_loggers/default)
│   ├── envoy-sdk v0.2.0-alpha.1
│   │   ├── anyhow v1.0.40
│   │   ├── bitflags v1.2.1
│   │   ├── log v0.4.14
│   │   │   └── cfg-if v1.0.0
│   │   └── proxy-wasm-experimental v0.0.8
│   │       ├── hashbrown v0.9.1
│   │       │   └── ahash v0.4.7
│   │       └── log v0.4.14 (*)
│   ├── serde v1.0.125
│   │   └── serde_derive v1.0.125 (proc-macro)
│   │       ├── proc-macro2 v1.0.26
│   │       │   └── unicode-xid v0.2.1
│   │       ├── quote v1.0.9
│   │       │   └── proc-macro2 v1.0.26 (*)
│   │       └── syn v1.0.69
│   │           ├── proc-macro2 v1.0.26 (*)
│   │           ├── quote v1.0.9 (*)
│   │           └── unicode-xid v0.2.1
│   └── serde_json v1.0.64
│       ├── itoa v0.4.7
│       ├── ryu v1.0.5
│       └── serde v1.0.125 (*)
└── envoy-sdk v0.2.0-alpha.1 (*)

```

Using nanoserde trims this notably:

```
envoy-sample-access-logger-module v0.1.0 (/Users/adrian/tetratelabs/getenvoy/data/extension/init/templates/rust/envoy.access_loggers/default/wasm/module)
├── envoy-sample-access-logger v0.1.0 (/Users/adrian/tetratelabs/getenvoy/data/extension/init/templates/rust/envoy.access_loggers/default)
│   ├── envoy-sdk v0.2.0-alpha.1
│   │   ├── anyhow v1.0.40
│   │   ├── bitflags v1.2.1
│   │   ├── log v0.4.14
│   │   │   └── cfg-if v1.0.0
│   │   └── proxy-wasm-experimental v0.0.8
│   │       ├── hashbrown v0.9.1
│   │       │   └── ahash v0.4.7
│   │       └── log v0.4.14 (*)
│   └── nanoserde v0.1.25
│       └── nanoserde-derive v0.1.16 (proc-macro)
└── envoy-sdk v0.2.0-alpha.1 (*)
```

This cuts almost half the time off a local laptop run of the Rust E2E
test.

Before:
```
real	9m59.718s
user	0m19.257s
sys	0m20.511s
```

Now:
```
real	5m23.800s
user	0m19.108s
sys	0m20.451s
```

```bash
$ make clean; make builders; make bin; rm -rf /tmp/cargohome; mkdir /tmp/cargohome; time E2E_EXTENSION_LANGUAGE=rust E2E_TOOLCHAIN_CONTAINER_OPTIONS="-v /tmp/cargohome:/tmp/cargohome -e CARGO_HOME=/tmp/cargohome" make e2e
```

Signed-off-by: Adrian Cole <adrian@tetrate.io>