### PR TITLE
run builders mount in delegated consistency

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -103,7 +103,7 @@ jobs:
           - extension-language: rust
             # Attempt to avoid re-downloading almost 200MB of deps per test that implies "getenvoy extension build"
             # This uses the RUNNER_TEMP variable directly to avoid having to mkdir a sub-path.
-            toolchain-container-options: "-v ${RUNNER_TEMP}:/tmp/cargohome -e CARGO_HOME=/tmp/cargohome"
+            toolchain-container-options: "-v ${RUNNER_TEMP}:/tmp/cargohome:delegated -e CARGO_HOME=/tmp/cargohome"
           - extension-language: tinygo
             toolchain-container-options: ""
     env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,7 +88,7 @@ jobs:
           - extension-language: rust
             # Attempt to avoid re-downloading almost 200MB of deps per test that implies "getenvoy extension build"
             # This uses the RUNNER_TEMP variable directly to avoid having to mkdir a sub-path.
-            toolchain-container-options: "-v ${RUNNER_TEMP}:/tmp/cargohome -e CARGO_HOME=/tmp/cargohome"
+            toolchain-container-options: "-v ${RUNNER_TEMP}:/tmp/cargohome:delegated -e CARGO_HOME=/tmp/cargohome"
           - extension-language: tinygo
             toolchain-container-options: ""
     env:

--- a/pkg/cmd/extension/build/cmd_test.go
+++ b/pkg/cmd/extension/build/cmd_test.go
@@ -106,7 +106,7 @@ func TestGetEnvoyExtensionBuild(t *testing.T) {
 	err := cmdutil.Execute(c)
 
 	// We expect docker to run from the correct path, as the current user and mount a volume for the correct workspace.
-	expectedDockerExec := fmt.Sprintf("%s/docker run -u %s:%s --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init getenvoy/extension-rust-builder:latest build --output-file target/getenvoy/extension.wasm",
+	expectedDockerExec := fmt.Sprintf("%s/docker run -u %s:%s --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init getenvoy/extension-rust-builder:latest build --output-file target/getenvoy/extension.wasm",
 		dockerDir, expectedUser.Uid, expectedUser.Gid, runtime.GOOS, workspaceDir)
 
 	// Verify the command invoked, passing the correct default commandline
@@ -162,7 +162,7 @@ func TestGetEnvoyExtensionBuildFail(t *testing.T) {
 	err := cmdutil.Execute(c)
 
 	// We expect the exit instruction to have gotten to the fake docker script, along with the default options.
-	expectedDockerExec := fmt.Sprintf("%s/docker run -u %s:%s --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init %s getenvoy/extension-rust-builder:latest build --output-file target/getenvoy/extension.wasm",
+	expectedDockerExec := fmt.Sprintf("%s/docker run -u %s:%s --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init %s getenvoy/extension-rust-builder:latest build --output-file target/getenvoy/extension.wasm",
 		dockerDir, expectedUser.Uid, expectedUser.Gid, runtime.GOOS, workspaceDir, toolchainOptions)
 
 	// Verify the command failed with the expected error.

--- a/pkg/cmd/extension/clean/cmd_test.go
+++ b/pkg/cmd/extension/clean/cmd_test.go
@@ -106,7 +106,7 @@ func TestGetEnvoyExtensionClean(t *testing.T) {
 	err := cmdutil.Execute(c)
 
 	// We expect docker to run from the correct path, as the current user and mount a volume for the correct workspace.
-	expectedDockerExec := fmt.Sprintf("%s/docker run -u %s:%s --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init getenvoy/extension-rust-builder:latest clean",
+	expectedDockerExec := fmt.Sprintf("%s/docker run -u %s:%s --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init getenvoy/extension-rust-builder:latest clean",
 		dockerDir, expectedUser.Uid, expectedUser.Gid, runtime.GOOS, workspaceDir)
 
 	// Verify the command invoked, passing the correct default commandline
@@ -162,7 +162,7 @@ func TestGetEnvoyExtensionCleanFail(t *testing.T) {
 	err := cmdutil.Execute(c)
 
 	// We expect the exit instruction to have gotten to the fake docker script, along with the default options.
-	expectedDockerExec := fmt.Sprintf("%s/docker run -u %s:%s --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init %s getenvoy/extension-rust-builder:latest clean",
+	expectedDockerExec := fmt.Sprintf("%s/docker run -u %s:%s --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init %s getenvoy/extension-rust-builder:latest clean",
 		dockerDir, expectedUser.Uid, expectedUser.Gid, runtime.GOOS, workspaceDir, toolchainOptions)
 
 	// Verify the command failed with the expected error.

--- a/pkg/cmd/extension/run/cmd_test.go
+++ b/pkg/cmd/extension/run/cmd_test.go
@@ -171,7 +171,7 @@ func TestGetEnvoyExtensionRun(t *testing.T) {
 
 	envoyBin := filepath.Join(config.envoyHome, "builds/standard/1.17.1", config.platform, "/bin/envoy")
 	// We expect docker to build from the correct path, as the current user and mount a volume for the correct workspace.
-	expectedStdout := fmt.Sprintf(`%s/docker run -u %s --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init getenvoy/extension-rust-builder:latest build --output-file target/getenvoy/extension.wasm
+	expectedStdout := fmt.Sprintf(`%s/docker run -u %s --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init getenvoy/extension-rust-builder:latest build --output-file target/getenvoy/extension.wasm
 envoy pwd: %s
 envoy bin: %s
 envoy args: -c %s/envoy.tmpl.yaml --admin-address-path /admin-address.txt`,
@@ -201,7 +201,7 @@ func TestGetEnvoyExtensionRunDockerFail(t *testing.T) {
 	err := cmdutil.Execute(c)
 
 	// We expect the exit instruction to have gotten to the fake docker script, along with the default options.
-	expectedDockerExec := fmt.Sprintf("%s/docker run -u %s --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init %s getenvoy/extension-rust-builder:latest build --output-file target/getenvoy/extension.wasm",
+	expectedDockerExec := fmt.Sprintf("%s/docker run -u %s --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init %s getenvoy/extension-rust-builder:latest build --output-file target/getenvoy/extension.wasm",
 		config.dockerDir, config.expectedUidGid, runtime.GOOS, config.workspaceDir, toolchainOptions)
 
 	// Verify the command failed with the expected error.

--- a/pkg/cmd/extension/test/cmd_test.go
+++ b/pkg/cmd/extension/test/cmd_test.go
@@ -106,7 +106,7 @@ func TestGetEnvoyExtensionTest(t *testing.T) {
 	err := cmdutil.Execute(c)
 
 	// We expect docker to run from the correct path, as the current user and mount a volume for the correct workspace.
-	expectedDockerExec := fmt.Sprintf("%s/docker run -u %s:%s --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init getenvoy/extension-rust-builder:latest build --output-file target/getenvoy/extension.wasm",
+	expectedDockerExec := fmt.Sprintf("%s/docker run -u %s:%s --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init getenvoy/extension-rust-builder:latest build --output-file target/getenvoy/extension.wasm",
 		dockerDir, expectedUser.Uid, expectedUser.Gid, runtime.GOOS, workspaceDir)
 
 	// Verify the command invoked, passing the correct default commandline
@@ -162,7 +162,7 @@ func TestGetEnvoyExtensionTestFail(t *testing.T) {
 	err := cmdutil.Execute(c)
 
 	// We expect the exit instruction to have gotten to the fake docker script, along with the default options.
-	expectedDockerExec := fmt.Sprintf("%s/docker run -u %s:%s --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init %s getenvoy/extension-rust-builder:latest test",
+	expectedDockerExec := fmt.Sprintf("%s/docker run -u %s:%s --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init %s getenvoy/extension-rust-builder:latest test",
 		dockerDir, expectedUser.Uid, expectedUser.Gid, runtime.GOOS, workspaceDir, toolchainOptions)
 
 	// Verify the command failed with the expected error.

--- a/pkg/extension/workspace/toolchain/builtin/toolchain.go
+++ b/pkg/extension/workspace/toolchain/builtin/toolchain.go
@@ -98,7 +98,7 @@ func (t *builtin) dockerCliArgs(container *config.ContainerConfig) (executil.Arg
 		"--rm",
 		"-e", "GETENVOY_GOOS=" + runtime.GOOS, // Allows builder images to act based on execution env
 		"-t", // to get interactive/colored output out of container
-		"-v", fmt.Sprintf("%s:%s", t.workspace.GetDir().GetRootDir(), "/source"),
+		"-v", fmt.Sprintf("%s:%s", t.workspace.GetDir().GetRootDir(), "/source:delegated"),
 		"-w", "/source",
 		"--init", // to ensure container will be responsive to SIGTERM signal
 	}.Add(container.Options...).Add(container.Image), nil

--- a/pkg/extension/workspace/toolchain/builtin/toolchain_test.go
+++ b/pkg/extension/workspace/toolchain/builtin/toolchain_test.go
@@ -62,7 +62,7 @@ func TestBuiltinToolchain(t *testing.T) {
                   image: default/image
 `,
 		tool:           build,
-		expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init default/image build --output-file extension.wasm\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+		expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init default/image build --output-file extension.wasm\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
 	},
 		{
 			name: "test using default container image",
@@ -72,7 +72,7 @@ func TestBuiltinToolchain(t *testing.T) {
                   image: default/image
 `,
 			tool:           test,
-			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init default/image test\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init default/image test\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
 		},
 		{
 			name: "clean using default container image",
@@ -82,7 +82,7 @@ func TestBuiltinToolchain(t *testing.T) {
                   image: default/image
 `,
 			tool:           clean,
-			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init default/image clean\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init default/image clean\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
 		},
 		{
 			name: "build using test container image",
@@ -101,7 +101,7 @@ func TestBuiltinToolchain(t *testing.T) {
                     image: test/image
 `,
 			tool:           build,
-			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init build/image build --output-file output/file.wasm\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init build/image build --output-file output/file.wasm\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
 		},
 		{
 			name: "build using test container image and Docker cli options",
@@ -127,7 +127,7 @@ func TestBuiltinToolchain(t *testing.T) {
                     - /host/path=/container/path
 `,
 			tool:           build,
-			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init -e VAR=VALUE build/image build --output-file output/file.wasm\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init -e VAR=VALUE build/image build --output-file output/file.wasm\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
 		},
 		{
 			name: "build fails with a non-0 exit code",
@@ -145,8 +145,8 @@ func TestBuiltinToolchain(t *testing.T) {
                     wasmFile: output/file.wasm
 `,
 			tool:           build,
-			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init -e DOCKER_EXIT_CODE=3 build/image build --output-file output/file.wasm\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
-			expectedErr:    fmt.Sprintf("failed to execute an external command \"%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init -e DOCKER_EXIT_CODE=3 build/image build --output-file output/file.wasm\": exit status 3", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init -e DOCKER_EXIT_CODE=3 build/image build --output-file output/file.wasm\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+			expectedErr:    fmt.Sprintf("failed to execute an external command \"%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init -e DOCKER_EXIT_CODE=3 build/image build --output-file output/file.wasm\": exit status 3", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
 		},
 		{
 			name: "test using test container image",
@@ -165,7 +165,7 @@ func TestBuiltinToolchain(t *testing.T) {
                     image: test/image
 `,
 			tool:           test,
-			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init test/image test\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init test/image test\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
 		},
 		{
 			name: "test using test container image and Docker cli options",
@@ -190,7 +190,7 @@ func TestBuiltinToolchain(t *testing.T) {
                     - /host/path=/container/path
 `,
 			tool:           test,
-			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init -v /host/path=/container/path test/image test\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init -v /host/path=/container/path test/image test\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
 		},
 		{
 			name: "test fails with a non-0 exit code",
@@ -206,8 +206,8 @@ func TestBuiltinToolchain(t *testing.T) {
                     - DOCKER_EXIT_CODE=3
 `,
 			tool:           test,
-			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init -e DOCKER_EXIT_CODE=3 test/image test\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
-			expectedErr:    fmt.Sprintf("failed to execute an external command \"%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init -e DOCKER_EXIT_CODE=3 test/image test\": exit status 3", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init -e DOCKER_EXIT_CODE=3 test/image test\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+			expectedErr:    fmt.Sprintf("failed to execute an external command \"%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init -e DOCKER_EXIT_CODE=3 test/image test\": exit status 3", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
 		},
 		{
 			name: "clean using test container image",
@@ -226,7 +226,7 @@ func TestBuiltinToolchain(t *testing.T) {
                     image: clean/image
 `,
 			tool:           clean,
-			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init clean/image clean\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init clean/image clean\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
 		},
 		{
 			name: "clean using test container image and Docker cli options",
@@ -251,7 +251,7 @@ func TestBuiltinToolchain(t *testing.T) {
                     - /host/path=/container/path
 `,
 			tool:           clean,
-			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init -v /host/path=/container/path clean/image clean\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init -v /host/path=/container/path clean/image clean\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
 		},
 		{
 			name: "clean fails with a non-0 exit code",
@@ -267,8 +267,8 @@ func TestBuiltinToolchain(t *testing.T) {
                     - DOCKER_EXIT_CODE=3
 `,
 			tool:           clean,
-			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init -e DOCKER_EXIT_CODE=3 clean/image clean\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
-			expectedErr:    fmt.Sprintf("failed to execute an external command \"%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source -w /source --init -e DOCKER_EXIT_CODE=3 clean/image clean\": exit status 3", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+			expectedStdout: fmt.Sprintf("%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init -e DOCKER_EXIT_CODE=3 clean/image clean\n", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
+			expectedErr:    fmt.Sprintf("failed to execute an external command \"%s/docker run -u 1001:1002 --rm -e GETENVOY_GOOS=%s -t -v %s:/source:delegated -w /source --init -e DOCKER_EXIT_CODE=3 clean/image clean\": exit status 3", dockerDir, runtime.GOOS, workspace.GetDir().GetRootDir()),
 		},
 	}
 


### PR DESCRIPTION
Defaults the source mount consistency to delegated, this speeds up builds a lot especially on Docker for Mac.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>