### PR TITLE
Fix not to handle error when cleaning under `api/`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ builders.pull: $(foreach lang,$(BUILDERS_LANGS), pull/builder/$(lang))
 .PHONY: api
 api: api/manifest.proto $(BUF) $(PROTOC_GEN_GO)
 	@echo "--- api ---"
-	@rm api/*.go
+	@rm -f api/*.go
 	@$(BUF) protoc \
 		--plugin=protoc-gen-go=$(PROTOC_GEN_GO) \
 		--go_out=paths=source_relative:. \


### PR DESCRIPTION
Signed-off-by: Kotaro Inoue <k.musaino@gmail.com>