### PR TITLE
Removes 386 release as no-one asked for it

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 project_name: getenvoy
-env:
-  - GO111MODULE=on
 builds:
 - binary: getenvoy
   ldflags: "-s -w -X github.com/tetratelabs/getenvoy/pkg/version.version={{.Version}}"
@@ -25,14 +23,12 @@ builds:
     - linux
     - darwin
   goarch:
-    - 386
     - amd64
 archives:
 - name_template: "getenvoy_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
   replacements:
     darwin: Darwin
     linux: Linux
-    386: i386
     amd64: x86_64
 checksum:
   name_template: 'checksums.txt'


### PR DESCRIPTION
Our goreleaser file differs from our Makefile in so far as including 386
arch. We should focus on what users are asking for instead.

This also removes the implicit go modules default as we set go to 1.16.
