### PR TITLE
Prefers quitting vs using an incoherent homedir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/mattn/go-runewidth v0.0.12 // indirect
 	github.com/mholt/archiver/v3 v3.5.0
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pierrec/lz4/v4 v4.1.6 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/schollz/progressbar/v3 v3.8.0

--- a/go.sum
+++ b/go.sum
@@ -169,7 +169,6 @@ github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceT
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -20,9 +20,9 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"os/user"
 	"path/filepath"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 
 	"github.com/tetratelabs/getenvoy/pkg/globals"
@@ -70,11 +70,11 @@ bootstrap generation and automated collection of access logs, Envoy state and ma
 func initializeGlobalOpts(globalOpts *globals.GlobalOpts) (string, string, error) {
 	homeDirFlag := os.Getenv("GETENVOY_HOME")
 	if homeDirFlag == "" && globalOpts.HomeDir == "" { // don't lookup homedir when overridden for tests
-		userHome, err := homedir.Dir()
-		if err != nil {
+		u, err := user.Current()
+		if err != nil || u.HomeDir == "" {
 			return "", "", fmt.Errorf("unable to determine home directory. Set GETENVOY_HOME instead: %w", err)
 		}
-		homeDirFlag = filepath.Join(userHome, ".getenvoy")
+		homeDirFlag = filepath.Join(u.HomeDir, ".getenvoy")
 	}
 
 	manifestURLFlag := os.Getenv("GETENVOY_MANIFEST_URL")

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -18,10 +18,10 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"testing"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
@@ -80,14 +80,14 @@ func TestGetEnvoyHomeDir(t *testing.T) {
 		expected string
 	}
 
-	userHome, err := homedir.Dir()
+	u, err := user.Current()
 	require.NoError(t, err)
 
 	tests := []testCase{ // we don't test default as that depends on the runtime env
 		{
 			name:     "default is ~/.getenvoy",
 			args:     []string{"help"},
-			expected: filepath.Join(userHome, ".getenvoy"),
+			expected: filepath.Join(u.HomeDir, ".getenvoy"),
 		},
 		{
 			name: "GETENVOY_HOME env",

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -18,8 +18,10 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
@@ -78,11 +80,14 @@ func TestGetEnvoyHomeDir(t *testing.T) {
 		expected string
 	}
 
+	userHome, err := homedir.Dir()
+	require.NoError(t, err)
+
 	tests := []testCase{ // we don't test default as that depends on the runtime env
 		{
 			name:     "default is ~/.getenvoy",
 			args:     []string{"help"},
-			expected: globals.DefaultHomeDir(),
+			expected: filepath.Join(userHome, ".getenvoy"),
 		},
 		{
 			name: "GETENVOY_HOME env",

--- a/pkg/globals/globals.go
+++ b/pkg/globals/globals.go
@@ -14,13 +14,6 @@
 
 package globals
 
-import (
-	"path/filepath"
-
-	"github.com/mitchellh/go-homedir"
-	"github.com/tetratelabs/log"
-)
-
 // RunOpts support invocations of "getenvoy run" and "getenvoy extension run"
 type RunOpts struct {
 	// EnvoyPath is the exec.Cmd path to "envoy". Defaults to "$HomeDir/builds/$flavor/$version/$platform/bin/envoy"
@@ -41,22 +34,10 @@ type RunOpts struct {
 type GlobalOpts struct {
 	// RunOpts are inlined to allow tests to override parameters without changing ENV variables or flags
 	RunOpts
-	// HomeDir most importantly contains envoy binaries fetched from ManifestURL. Defaults to DefaultHomeDir
+	// HomeDir most importantly contains envoy binaries fetched from ManifestURL. Defaults to homedir.Dir/.getenvoy
 	HomeDir string
 	// ManifestURL is the path to the getenvoy manifest json
 	ManifestURL string
-}
-
-// DefaultHomeDir returns the value for RunOpts.HomeDir. Defaults to homedir.Dir/.getenvoy
-// Intentionally defer this to prevent log warnings.
-func DefaultHomeDir() string {
-	home, err := homedir.Dir()
-	dir := filepath.Join(home, ".getenvoy")
-	if err != nil {
-		log.Errorf("unable to determine the user home directory: %v", err)
-		log.Warnf("default GetEnvoy home directory will have a non-standard value %q", dir)
-	}
-	return dir
 }
 
 // DefaultManifestURL is the default value for GlobalOpts.ManifestURL

--- a/pkg/globals/globals.go
+++ b/pkg/globals/globals.go
@@ -34,7 +34,7 @@ type RunOpts struct {
 type GlobalOpts struct {
 	// RunOpts are inlined to allow tests to override parameters without changing ENV variables or flags
 	RunOpts
-	// HomeDir most importantly contains envoy binaries fetched from ManifestURL. Defaults to homedir.Dir/.getenvoy
+	// HomeDir most importantly contains envoy binaries fetched from ManifestURL. Defaults to $HOME/.getenvoy
 	HomeDir string
 	// ManifestURL is the path to the getenvoy manifest json
 	ManifestURL string


### PR DESCRIPTION
Recent refactoring deferred lookup of the user home dir until after
GETENVOY_HOME is checked. This prefers being strict vs using an
undefined value on error determining the user home.

Signed-off-by: Adrian Cole <adrian@tetrate.io>