### PR TITLE
Uses normal regex instead of lib dep in unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ module github.com/tetratelabs/getenvoy
 go 1.16
 
 require (
-	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect
 	github.com/andybalholm/brotli v1.0.2 // indirect
 	github.com/go-ole/go-ole v1.2.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,6 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
-github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 h1:5sXbqlSomvdjlRbWyNqkPsJ3Fg+tQZCbgeX1VGljbQY=

--- a/pkg/binary/envoy/fetch_test.go
+++ b/pkg/binary/envoy/fetch_test.go
@@ -15,6 +15,7 @@
 package envoy
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -32,6 +33,8 @@ import (
 	"github.com/tetratelabs/getenvoy/pkg/test/morerequire"
 )
 
+const envoyVersion = "1.17.2" // This is only for unit testing: we don't need to use latest.
+
 func TestFetchIfNeeded(t *testing.T) {
 	o := &globals.GlobalOpts{}
 	homeDir, removeHomeDir := morerequire.RequireNewTempDir(t)
@@ -39,7 +42,7 @@ func TestFetchIfNeeded(t *testing.T) {
 	o.HomeDir = homeDir
 
 	// Hard code even if the unit test env isn't darwin. This avoids drifts like linux vs linux-glibc
-	r := "standard:1/darwin"
+	r := fmt.Sprintf("standard:%s/darwin", envoyVersion)
 	testManifest, err := manifesttest.NewSimpleManifest(r)
 	require.NoError(t, err, `error creating test manifest`)
 
@@ -54,7 +57,7 @@ func TestFetchIfNeeded(t *testing.T) {
 
 	o.ManifestURL = manifestServer.URL + "/manifest.json"
 
-	expectedPath := filepath.Join(homeDir, "builds", "standard", "1", "darwin", "bin", "envoy")
+	expectedPath := filepath.Join(homeDir, "builds", "standard", envoyVersion, "darwin", "bin", "envoy")
 	t.Run("downloads when doesn't exists", func(t *testing.T) {
 		envoyPath, e := FetchIfNeeded(o, r)
 		require.NoError(t, e)
@@ -79,7 +82,7 @@ func TestFetchIfNeeded(t *testing.T) {
 
 func TestFetchIfNeededAlreadyExists(t *testing.T) {
 	// Hard code even if the unit test env isn't darwin. This avoids drifts like linux vs linux-glibc
-	r := "standard:1/darwin"
+	r := fmt.Sprintf("standard:%s/darwin", envoyVersion)
 	testManifest, err := manifesttest.NewSimpleManifest(r)
 	require.NoError(t, err, `error creating test manifest`)
 
@@ -94,7 +97,7 @@ func TestFetchIfNeededAlreadyExists(t *testing.T) {
 
 	envoyPath, err := FetchIfNeeded(o, r)
 	require.NoError(t, err)
-	require.Equal(t, filepath.Join(homeDir, "builds", "standard", "1", "darwin", "bin", "envoy"), envoyPath)
+	require.Equal(t, filepath.Join(homeDir, "builds", "standard", envoyVersion, "darwin", "bin", "envoy"), envoyPath)
 	require.FileExists(t, envoyPath)
 }
 

--- a/pkg/test/manifest/server.go
+++ b/pkg/test/manifest/server.go
@@ -69,7 +69,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (s *server) validateReference(uri string) {
 	ref, err := manifest.ParseReference(uri)
 	require.NoError(s.t, err, "could not parse reference from uri %q", uri)
-	require.Regexpf(s.t, `^1\.[1-9][7]\.[0-9]+$`, ref.Version, "unsupported version in uri %q", uri)
+	require.Regexpf(s.t, `^1\.[1-9][0-9]\.[0-9]+$`, ref.Version, "unsupported version in uri %q", uri)
 }
 
 func (s *server) GetManifest() []byte {

--- a/pkg/test/manifest/server.go
+++ b/pkg/test/manifest/server.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -70,10 +69,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (s *server) validateReference(uri string) {
 	ref, err := manifest.ParseReference(uri)
 	require.NoError(s.t, err, "could not parse reference from uri %q", uri)
-	ver, err := semver.NewVersion(ref.Version)
-	require.NoError(s.t, err, "could not parse version from uri %q", uri)
-	require.GreaterOrEqualf(s.t, uint64(1), ver.Major(), "unsupported major version in uri %q", uri)
-	require.GreaterOrEqualf(s.t, uint64(17), ver.Minor(), "unsupported minor version in uri %q", uri)
+	require.Regexpf(s.t, `^1\.[1-9][7]\.[0-9]+$`, ref.Version, "unsupported version in uri %q", uri)
 }
 
 func (s *server) GetManifest() []byte {


### PR DESCRIPTION
Signed-off-by: Adrian Cole <adrian@tetrate.io>