### PR TITLE
Drops compile dep on archiver/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect
 	github.com/go-ole/go-ole v1.2.5 // indirect
 	github.com/mattn/go-runewidth v0.0.12 // indirect
-	github.com/mholt/archiver/v3 v3.5.0
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/schollz/progressbar/v3 v3.8.0
 	github.com/shirou/gopsutil/v3 v3.21.4

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 h1:5sXbqlSomvdjl
 github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/andybalholm/brotli v1.0.0 h1:7UCwP93aiSfvWpapti8g88vVVGp2qqtGyePsSuDafo4=
-github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -42,9 +40,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/dsnet/compress v0.0.1 h1:PlZu0n3Tuv04TzpfPbrnI0HW/YwodEXDS+oPKahKF0Q=
-github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
-github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -66,8 +61,6 @@ github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFU
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
-github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -113,12 +106,6 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
-github.com/klauspost/compress v1.10.10 h1:a/y8CglcM7gLGYmlbP/stPE5sR3hbhFRUjCBfd/0B3I=
-github.com/klauspost/compress v1.10.10/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
-github.com/klauspost/pgzip v1.2.4 h1:TQ7CNpYKovDOmqzRHKxJh0BeaBI7UdQZYc6p7pMQh1A=
-github.com/klauspost/pgzip v1.2.4/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -134,8 +121,6 @@ github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRC
 github.com/mattn/go-runewidth v0.0.12 h1:Y41i/hVW3Pgwr8gV+J23B9YEY0zxjptBuCWEaxmAOow=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mholt/archiver/v3 v3.5.0 h1:nE8gZIrw66cu4osS/U7UW7YDuGMHssxKutU8IfWxwWE=
-github.com/mholt/archiver/v3 v3.5.0/go.mod h1:qqTTPUK/HZPFgFQ/TJ3BzvTpF/dPtFVJXdQbCmeMxwc=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
@@ -150,13 +135,9 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
-github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/pierrec/lz4/v4 v4.0.3 h1:vNQKSVZNYUEAvRY9FaUXAF1XPbSOHJtDTiP41kzDz2E=
-github.com/pierrec/lz4/v4 v4.0.3/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -215,12 +196,8 @@ github.com/tklauser/numcpus v0.2.1/go.mod h1:9aU+wOc6WjUIZEwWMP62PL/41d65P+iks1g
 github.com/tklauser/numcpus v0.2.2 h1:oyhllyrScuYI6g+h/zUvNXNp1wy7x8qQy3t/piefldA=
 github.com/tklauser/numcpus v0.2.2/go.mod h1:x3qojaO3uyYt0i56EW/VUYs7uBvdl2fkfZFu0T9wgjM=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
-github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
-github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/internal/tar/tar.go
+++ b/internal/tar/tar.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package tar avoids a large (~3MB) dependency on archiver/v3. These are special-cased to the needs of getenvoy.
+// Package tar avoids third-party dependencies (ex archiver/v3) and are special-cased to the needs of getenvoy.
 package tar
 
 import (

--- a/internal/tar/tar.go
+++ b/internal/tar/tar.go
@@ -17,9 +17,8 @@ package tar
 
 import (
 	"archive/tar"
+	"bufio"
 	"compress/gzip"
-	"errors"
-	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -29,26 +28,24 @@ import (
 	"github.com/ulikunitz/xz"
 )
 
-// NewDecompressor returns a compression function based on the "src" filename.
-// NOTE: As of May 2021, all Envoy binaries except the first are tar.xz
-func NewDecompressor(src string, r io.Reader) (io.ReadCloser, error) {
-	if strings.HasSuffix(src, "tar.xz") {
-		zr, err := xz.NewReader(r)
-		if err != nil {
-			return nil, fmt.Errorf("not a valid xz stream %s: %w", src, err)
-		}
-		return io.NopCloser(zr), nil
-	}
-	zr, err := gzip.NewReader(r)
-	if err != nil {
-		return nil, fmt.Errorf("not a valid gz stream %s: %w", src, err)
-	}
-	return zr, nil
-}
-
-// Untar unarchives, stripping the base directory inside the "src" archive. Ex on "/foo/bar", "dst" will have "bar/**"
+// Untar unarchives the compressed "src" which is either a "tar.xz" or "tar.gz" stream.
+// This strips the base directory inside the "src" archive. Ex on "/foo/bar", "dst" will have "bar/**"
+//
+// This is used to decompress Envoy distributions in the "downloadLocationURL" field of "manifest.json".
+// To keep the binary size small, only supports compression formats used in practice. As of May 2021, all
+// "downloadLocationURL" values were "tar.xz", except the first (1.11.0), which was "tar.gz".
 func Untar(dst string, src io.Reader) error { // dst, src order like io.Copy
-	tr := tar.NewReader(src)
+	if e := os.MkdirAll(dst, 0750); e != nil {
+		return e
+	}
+
+	zSrc, e := newDecompressor(src)
+	if e != nil {
+		return e
+	}
+	defer zSrc.Close() //nolint
+
+	tr := tar.NewReader(zSrc)
 	for {
 		header, err := tr.Next()
 		if err == io.EOF {
@@ -80,6 +77,23 @@ func Untar(dst string, src io.Reader) error { // dst, src order like io.Copy
 	return nil
 }
 
+// newDecompressor returns an "xz" or "gzip" decompression function based on bytes in the stream.
+func newDecompressor(r io.Reader) (io.ReadCloser, error) {
+	br := bufio.NewReader(r)
+	h, err := br.Peek(xz.HeaderLen)
+	if err != nil { // This is only used to decompress Envoy, so a valid stream will never be this short.
+		return nil, err
+	}
+	if xz.ValidHeader(h) {
+		xzr, e := xz.NewReader(br)
+		if e != nil {
+			return nil, err
+		}
+		return io.NopCloser(xzr), nil
+	}
+	return gzip.NewReader(br)
+}
+
 func extractFile(dst string, src io.Reader, perm os.FileMode) error {
 	file, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm) //nolint:gosec
 	if err != nil {
@@ -90,18 +104,27 @@ func extractFile(dst string, src io.Reader, perm os.FileMode) error {
 	return err
 }
 
-// Tar archives the source, rooted at the given directory.
-// Ex Given "src" includes "envoy-2/bin" and "build/bin". If "root" is "envoy-2", the archive includes "envoy-2/bin".
-func Tar(dst io.Writer, src fs.FS, root string) error { // dst, src order like io.Copy
-	if root == "" {
-		return errors.New("root must not be empty")
+// TarGz tars and gzips "src", rooted at the last directory, into the file named "dst"
+// Ex If "src" includes "/tmp/envoy/bin" and "/tmp/build/bin". If "src" is "/tmp/envoy", "dst" includes "envoy/bin".
+//
+// This is used to compress the working directory of Envoy after it is stopped.
+func TarGz(dst, src string) error { //nolint dst, src order like io.Copy
+	srcFS := os.DirFS(filepath.Dir(src))
+	basePath := filepath.Base(src)
+
+	// create the tar.gz file
+	file, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600) //nolint:gosec
+	if err != nil {
+		return err
 	}
-	tw := tar.NewWriter(dst)
+	defer file.Close() //nolint
+	gzw := gzip.NewWriter(file)
+	defer gzw.Close() //nolint
+	tw := tar.NewWriter(gzw)
 	defer tw.Close() //nolint
 
-	basePath := filepath.Dir(root)
 	// Recurse through the path including all files and directories
-	return fs.WalkDir(src, root, func(path string, d os.DirEntry, err error) error {
+	return fs.WalkDir(srcFS, basePath, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -116,8 +139,8 @@ func Tar(dst io.Writer, src fs.FS, root string) error { // dst, src order like i
 			return err
 		}
 
-		// Ensure the destination file starts at the intended basePath
-		header.Name = filepath.Join(basePath, path)
+		// Ensure the destination file starts at the intended path
+		header.Name = path
 		if err := tw.WriteHeader(header); err != nil {
 			return err
 		}
@@ -125,7 +148,7 @@ func Tar(dst io.Writer, src fs.FS, root string) error { // dst, src order like i
 		if info.IsDir() {
 			return nil // nothing to write
 		}
-		return copy(tw, src, path)
+		return copy(tw, srcFS, path)
 	})
 }
 

--- a/internal/tar/tar_test.go
+++ b/internal/tar/tar_test.go
@@ -129,7 +129,7 @@ func requireTarTestData(t *testing.T, tempDir string) string {
 	require.NoError(t, e)
 	defer f.Close()
 
-	e = tar.Tar(f, "testdata", "foo")
+	e = tar.Tar(f, os.DirFS("testdata"), "foo")
 	require.NoError(t, e)
 	return f.Name()
 }

--- a/pkg/binary/envoy/fetch_test.go
+++ b/pkg/binary/envoy/fetch_test.go
@@ -117,7 +117,7 @@ func TestUntarEnvoy(t *testing.T) {
 				binDir := filepath.Join(tempDir, test.path, "bin")
 				require.NoError(t, os.MkdirAll(binDir, 0700))
 				require.NoError(t, ioutil.WriteFile(filepath.Join(binDir, "envoy"), []byte("fake"), 0700))
-				require.NoError(t, tar.Tar(zw, tempDir, test.path))
+				require.NoError(t, tar.Tar(zw, os.DirFS(tempDir), test.path))
 			}))
 			defer server.Close()
 

--- a/pkg/binary/envoy/termination.go
+++ b/pkg/binary/envoy/termination.go
@@ -66,7 +66,7 @@ func (r *Runtime) handlePostTermination() error {
 	zw := gzip.NewWriter(targz)
 	defer zw.Close() //nolint
 
-	if err = tar.Tar(zw, dirName, baseName); err != nil {
+	if err = tar.Tar(zw, os.DirFS(dirName), baseName); err != nil {
 		return fmt.Errorf("unable to archive run directory %v: %w", r.GetWorkingDir(), err)
 	}
 	return os.RemoveAll(r.GetWorkingDir())

--- a/pkg/binary/envoy/termination.go
+++ b/pkg/binary/envoy/termination.go
@@ -15,7 +15,6 @@
 package envoy
 
 import (
-	"compress/gzip"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -58,15 +57,7 @@ func (r *Runtime) handlePostTermination() error {
 	baseName := filepath.Base(r.GetWorkingDir())            // 1620955405964267000
 	targzName := filepath.Join(dirName, baseName+".tar.gz") // ~/.getenvoy/debug/1620955405964267000.tar.gz
 
-	targz, err := os.Create(targzName)
-	if err != nil {
-		return err
-	}
-	defer targz.Close() //nolint
-	zw := gzip.NewWriter(targz)
-	defer zw.Close() //nolint
-
-	if err = tar.Tar(zw, os.DirFS(dirName), baseName); err != nil {
+	if err := tar.TarGz(targzName, r.GetWorkingDir()); err != nil {
 		return fmt.Errorf("unable to archive run directory %v: %w", r.GetWorkingDir(), err)
 	}
 	return os.RemoveAll(r.GetWorkingDir())

--- a/pkg/test/manifest/manifest.go
+++ b/pkg/test/manifest/manifest.go
@@ -15,8 +15,6 @@
 package manifest
 
 import (
-	"fmt"
-
 	"github.com/tetratelabs/getenvoy/pkg/manifest"
 )
 
@@ -53,7 +51,7 @@ func NewSimpleManifest(reference string) (*manifest.Manifest, error) {
 	for _, platform := range platforms {
 		version.Builds[platform] = &manifest.Build{
 			Platform:            platform,
-			DownloadLocationURL: fmt.Sprintf("%s.tar.xz", ref.String()),
+			DownloadLocationURL: ref.String(),
 		}
 	}
 	return m, nil

--- a/pkg/test/manifest/server.go
+++ b/pkg/test/manifest/server.go
@@ -105,6 +105,6 @@ echo >&2 envoy stderr
 	zw, err := xz.NewWriter(w)
 	require.NoError(s.t, err)
 	defer zw.Close() //nolint
-	err = tar.Tar(zw, tempDir, version)
+	err = tar.Tar(zw, os.DirFS(tempDir), version)
 	require.NoError(s.t, err)
 }

--- a/test/e2e/getenvoy_run_test.go
+++ b/test/e2e/getenvoy_run_test.go
@@ -101,11 +101,7 @@ func verifyDebugDump(t *testing.T, workingDir string, c interface{}) {
 
 	src, err := os.Open(debugArchive)
 	require.NoError(t, err, "error opening %s after stopping [%v]", debugArchive, c)
-	zSrc, err := tar.NewDecompressor(debugArchive, src)
-	require.NoError(t, err, "error getting decompressor for %s after stopping [%v]", debugArchive, c)
-	defer zSrc.Close() //nolint
-
-	e := tar.Untar(workingDir, zSrc)
+	e := tar.Untar(workingDir, src)
 	require.NoError(t, e, "error restoring %s from %s after stopping [%v]", workingDir, debugArchive, c)
 
 	// ensure the minimum contents exist


### PR DESCRIPTION
This removes the dependency on "archiver/v3" from the binary because
* It has no support for streaming https://github.com/mholt/archiver/pull/199, so we had to buffer to disk first
* Including "archiver/v3" makes it easy to accidentally bloat the binary (we did this by 25% before)
* The result is simpler dependencies

Before:
```bash
$ du -sk build/bin/*/*/getenvoy
8020	build/bin/darwin/amd64
7528	build/bin/linux/amd64
```

```bash
$ du -sk build/bin/*/*/getenvoy
7728	build/bin/darwin/amd64
7264	build/bin/linux/amd64
```