### PR TITLE
Simplifies coverage configuration and replaces manual analysis with codecov.io

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -62,13 +62,8 @@ jobs:
       - name: "Run e2e tests using the `getenvoy` binary"
         run: make e2e
 
-      - name: "Generate test coverage report"
+      - name: "Generate and upload coverage report"
         if: runner.os == 'Linux'  # no need to do this per operating system
-        run: make coverage
-
-      - name: "Upload test coverage report"
-        uses: actions/upload-artifact@v2
-        if: runner.os == 'Linux'  # no need to do this per operating system
-        with:
-          name: coverage
-          path: coverage
+        run: |  # This uses the $CODECOV_TOKEN repository secret
+          make coverage
+          bash <(curl -s https://codecov.io/bash) -f coverage/coverage.txt

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -71,4 +71,4 @@ jobs:
         if: runner.os == 'Linux'  # no need to do this per operating system
         with:
           name: coverage
-          path: build/coverage
+          path: coverage

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 /getenvoy
 /build/
 .idea
+/coverage/

--- a/Makefile
+++ b/Makefile
@@ -87,9 +87,11 @@ $(foreach os,$(GOOSES),$(foreach arch,$(GOARCHS),$(eval $(call GEN_BIN_GOOS_GOAR
 COVERAGE_PACKAGES ?= $(shell echo $(TEST_PKG_LIST)| tr -s " " ",")
 .PHONY: coverage
 coverage:
-	mkdir coverage
-	go test -coverprofile=coverage/coverage.txt --coverpkg $(COVERAGE_PACKAGES) $(TEST_PKG_LIST)
-	go tool cover -html=coverage/coverage.txt -o coverage/coverage.html
+	@echo "--- coverage ---"
+	@rm -rf coverage
+	@mkdir coverage
+	@go test -coverprofile=coverage/coverage.txt -covermode=atomic --coverpkg $(COVERAGE_PACKAGES) $(TEST_PKG_LIST)
+	@go tool cover -html=coverage/coverage.txt -o coverage/coverage.html
 
 ##@ Code quality and integrity
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Coverage](https://codecov.io/gh/tetratelabs/getenvoy/branch/master/graph/badge.svg)](https://codecov.io/gh/tetratelabs/getenvoy)
 [![Go Report Card](https://goreportcard.com/badge/github.com/tetratelabs/getenvoy)](https://goreportcard.com/report/github.com/tetratelabs/getenvoy)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+
 # GetEnvoy
 
 **GetEnvoy is spread across multiple repos. For more details head over to [GetEnvoy.io](https://getenvoy.io/github).**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build](https://github.com/tetratelabs/getenvoy/workflows/build/badge.svg)](https://github.com/tetratelabs/getenvoy)
+[![Coverage](https://codecov.io/gh/tetratelabs/getenvoy/branch/master/graph/badge.svg)](https://codecov.io/gh/tetratelabs/getenvoy)
+[![Go Report Card](https://goreportcard.com/badge/github.com/tetratelabs/getenvoy)](https://goreportcard.com/report/github.com/tetratelabs/getenvoy)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-
 # GetEnvoy
 
 **GetEnvoy is spread across multiple repos. For more details head over to [GetEnvoy.io](https://getenvoy.io/github).**


### PR DESCRIPTION
This removes so many variable no one would set, fixes coverage packages and makes sure it builds into the ./coverage directory. Coverage is now analyzed with codecov.io

Fixes #186