### PR TITLE
Adds release date to version list output

### DIFF
--- a/e2e/getenvoy_test.go
+++ b/e2e/getenvoy_test.go
@@ -38,7 +38,8 @@ func TestGetEnvoyVersions(t *testing.T) {
 
 	stdout, stderr, err := getEnvoy("versions").exec()
 
-	require.Contains(t, stdout, fmt.Sprintln(version.LastKnownEnvoy))
+	require.Regexp(t, "^VERSION\tRELEASE_DATE\n", stdout)
+	require.Regexp(t, fmt.Sprintf("%s\t202[1-9]-[01][0-9]-[0-3][0-9]\n", version.LastKnownEnvoy), stdout)
 	require.Empty(t, stderr)
 	require.NoError(t, err)
 }

--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -31,7 +31,8 @@ func NewVersionsCmd(o *globals.GlobalOpts) *cli.Command {
 			if err != nil {
 				return err
 			}
-			return envoy.PrintVersions(m, envoy.CurrentPlatform(), c.App.Writer)
+			envoy.PrintVersions(m, envoy.CurrentPlatform(), c.App.Writer)
+			return nil
 		},
 	}
 }

--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -31,8 +31,7 @@ func NewVersionsCmd(o *globals.GlobalOpts) *cli.Command {
 			if err != nil {
 				return err
 			}
-			envoy.PrintVersions(m, envoy.CurrentPlatform(), c.App.Writer)
-			return nil
+			return envoy.PrintVersions(m, envoy.CurrentPlatform(), c.App.Writer)
 		},
 	}
 }

--- a/internal/cmd/versions_test.go
+++ b/internal/cmd/versions_test.go
@@ -34,6 +34,8 @@ func TestGetEnvoyVersions(t *testing.T) {
 
 	// Verify the command invoked, passing the correct default commandline
 	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintln(version.LastKnownEnvoy), stdout.String())
+	require.Equal(t, fmt.Sprintf(`VERSION	RELEASE_DATE
+%s	2020-12-31
+`, version.LastKnownEnvoy), stdout.String())
 	require.Empty(t, stderr)
 }

--- a/internal/envoy/versions_test.go
+++ b/internal/envoy/versions_test.go
@@ -52,16 +52,21 @@ func TestPrintVersions(t *testing.T) {
 			name:     "unsupported OS",
 			platform: "windows/amd64",
 			versions: goodVersions,
+			expected: `VERSION	RELEASE_DATE
+`,
 		},
 		{
 			name:     "unsupported Arch",
 			platform: "linux/arm64",
 			versions: goodVersions,
+			expected: `VERSION	RELEASE_DATE
+`,
 		},
 		{
 			name:     "empty version list",
 			platform: "darwin/amd64",
-			expected: ``,
+			expected: `VERSION	RELEASE_DATE
+`,
 		},
 	}
 

--- a/internal/envoy/versions_test.go
+++ b/internal/envoy/versions_test.go
@@ -33,16 +33,19 @@ func TestPrintVersions(t *testing.T) {
 			name:     "darwin",
 			platform: "darwin/amd64",
 			versions: goodVersions,
-			expected: `1.18.3
-1.14.7
+			expected: `VERSION	RELEASE_DATE
+1.18.3	2021-05-11
+1.14.7	2021-04-15
 `,
 		},
 		{
 			name:     "linux",
 			platform: "linux/amd64",
 			versions: goodVersions,
-			expected: `1.17.3
-1.14.7
+			expected: `VERSION	RELEASE_DATE
+1.18.3	2021-05-11
+1.17.3	2021-05-11
+1.14.7	2021-04-15
 `,
 		},
 		{
@@ -76,19 +79,23 @@ var goodVersions = version.EnvoyVersions{
 	LatestVersion: "1.18.3",
 	Versions: map[string]version.EnvoyVersion{
 		"1.14.7": {
+			ReleaseDate: "2021-04-15",
 			Tarballs: map[string]string{
+				"darwin/amd64": "https://getenvoy.io/versions/1.14.7/envoy-1.14.7-darwin-x86_64.tar.gz",
 				"linux/amd64":  "https://getenvoy.io/versions/1.14.7/envoy-1.14.7-linux-x86_64.tar.gz",
-				"darwin/amd64": "https://getenvoy.io/versions/1.14.7/envoy-1.14.7-darwin/amd64-x86_64.tar.gz",
 			},
 		},
 		"1.17.3": {
+			ReleaseDate: "2021-05-11",
 			Tarballs: map[string]string{
 				"linux/amd64": "https://getenvoy.io/versions/1.17.3/envoy-1.17.3-linux-x86_64.tar.gz",
 			},
 		},
 		"1.18.3": {
+			ReleaseDate: "2021-05-11",
 			Tarballs: map[string]string{
-				"darwin/amd64": "https://getenvoy.io/versions/1.18.3/envoy-1.18.3-darwin/amd64-x86_64.tar.gz",
+				"darwin/amd64": "https://getenvoy.io/versions/1.18.3/envoy-1.18.3-darwin-x86_64.tar.gz",
+				"linux/amd64":  "https://getenvoy.io/versions/1.18.3/envoy-1.18.3-linux-x86_64.tar.gz",
 			},
 		},
 	},

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -44,8 +44,8 @@ func RequireEnvoyVersionsTestServer(t *testing.T, v string) *httptest.Server {
 	h := httptest.NewServer(s)
 	s.versions = version.EnvoyVersions{
 		LatestVersion: v,
-		Versions: map[string]version.EnvoyVersion{
-			v: {Tarballs: map[string]string{
+		Versions: map[string]version.EnvoyVersion{ // hard-code date so that tests don't drift
+			v: {ReleaseDate: "2020-12-31", Tarballs: map[string]string{
 				"linux/" + runtime.GOARCH:  TarballURL(h.URL, "linux", runtime.GOARCH, v),
 				"darwin/" + runtime.GOARCH: TarballURL(h.URL, "darwin", runtime.GOARCH, v),
 			}}},


### PR DESCRIPTION
Ex.
```bash
$ dist/getenvoy_darwin_amd64/getenvoy versions
VERSION	RELEASE_DATE
1.18.3	2021-05-11
1.17.3	2021-05-11
1.16.4	2021-05-11
1.15.5	2021-05-11
1.14.7	2021-04-15
```

fixes #93