### PR TITLE
Enables e2e testing of arm64 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 # See https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration
 # run `travis lint` prior to check-in!
 os: linux   # required for arch different than amd64
-arch: amd64  # TODO arm64-graviton2 # we only only test archs not already tested with GH actions
+arch: arm64-graviton2 # we only only test archs not already tested with GH actions
 group: edge  # required for arm64-graviton2
 virt: lxd  # faster starting
 language: go
 
 go:
   - 1.16.5
+
+env:  # site/envoy-versions.json doesn't yet include arm64
+  - ENVOY_VERSIONS_URL=https://raw.githubusercontent.com/tetratelabs/temprepo/master/envoy-versions.json
 
 git:
   depth: false  # TRAVIS_COMMIT_RANGE requires full commit history.


### PR DESCRIPTION
By using travis instead of a self-hosted github action, we don't pay anything to test arm64 and neither do non-employees who fork our repository.

This uses a temporary version list until our main one includes arm64

#109