### PR TITLE
Removes need to specify an envoy version when running

### DIFF
--- a/e2e/getenvoy_run_test.go
+++ b/e2e/getenvoy_run_test.go
@@ -38,7 +38,7 @@ func TestGetEnvoyRun(t *testing.T) {
 
 	c := getEnvoy(`run`)
 	// Below is the minimal config needed to run envoy
-	c.args(`--config-yaml`, `admin: {access_log_path: '/dev/stdout', address: {socket_address: {address: '127.0.0.1', port_value: 0}}}`)
+	c.args("--config-yaml", "admin: {access_log_path: '/dev/stdout', address: {socket_address: {address: '127.0.0.1', port_value: 0}}}")
 
 	stdout, stderr, terminate := c.start(t, terminateTimeout)
 

--- a/e2e/getenvoy_run_test.go
+++ b/e2e/getenvoy_run_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tetratelabs/getenvoy/internal/tar"
-	"github.com/tetratelabs/getenvoy/internal/version"
 )
 
 const terminateTimeout = 2 * time.Minute
@@ -39,8 +38,7 @@ func TestGetEnvoyRun(t *testing.T) {
 
 	c := getEnvoy(`run`)
 	// Below is the minimal config needed to run envoy
-	// TODO allow implicit version #106
-	c.args(version.LastKnownEnvoy, `--config-yaml`, `admin: {access_log_path: '/dev/stdout', address: {socket_address: {address: '127.0.0.1', port_value: 0}}}`)
+	c.args(`--config-yaml`, `admin: {access_log_path: '/dev/stdout', address: {socket_address: {address: '127.0.0.1', port_value: 0}}}`)
 
 	stdout, stderr, terminate := c.start(t, terminateTimeout)
 

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -86,8 +86,7 @@ var helpCommand = &cli.Command{
 		if args.Present() {
 			return cli.ShowCommandHelp(c, args.First())
 		}
-		_ = cli.ShowAppHelp(c)
-		return nil
+		return cli.ShowAppHelp(c)
 	},
 }
 

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -77,7 +77,7 @@ func TestGetEnvoyHomeDir(t *testing.T) {
 			name: "GETENVOY_HOME env",
 			args: []string{"getenvoy"},
 			setup: func() func() {
-				return requireSetenv(t, "GETENVOY_HOME", "/from/GETENVOY_HOME/env")
+				return morerequire.RequireSetenv(t, "GETENVOY_HOME", "/from/GETENVOY_HOME/env")
 			},
 			expected: "/from/GETENVOY_HOME/env",
 		},
@@ -90,7 +90,7 @@ func TestGetEnvoyHomeDir(t *testing.T) {
 			name: "prioritizes --home-dir arg over GETENVOY_HOME env",
 			args: []string{"getenvoy", "--home-dir", "/from/home-dir/arg"},
 			setup: func() func() {
-				return requireSetenv(t, "GETENVOY_HOME", "/from/GETENVOY_HOME/env")
+				return morerequire.RequireSetenv(t, "GETENVOY_HOME", "/from/GETENVOY_HOME/env")
 			},
 			expected: "/from/home-dir/arg",
 		},
@@ -133,7 +133,7 @@ func TestEnvoyVersionsURL(t *testing.T) {
 			name: "ENVOY_VERSIONS_URL env",
 			args: []string{"getenvoy"},
 			setup: func() func() {
-				return requireSetenv(t, "ENVOY_VERSIONS_URL", "http://ENVOY_VERSIONS_URL/env")
+				return morerequire.RequireSetenv(t, "ENVOY_VERSIONS_URL", "http://ENVOY_VERSIONS_URL/env")
 			},
 			expected: "http://ENVOY_VERSIONS_URL/env",
 		},
@@ -146,7 +146,7 @@ func TestEnvoyVersionsURL(t *testing.T) {
 			name: "prioritizes --envoy-versions-url arg over ENVOY_VERSIONS_URL env",
 			args: []string{"getenvoy", "--envoy-versions-url", "http://versions/arg"},
 			setup: func() func() {
-				return requireSetenv(t, "ENVOY_VERSIONS_URL", "http://ENVOY_VERSIONS_URL/env")
+				return morerequire.RequireSetenv(t, "ENVOY_VERSIONS_URL", "http://ENVOY_VERSIONS_URL/env")
 			},
 			expected: "http://versions/arg",
 		},
@@ -204,17 +204,6 @@ func TestGetEnvoyUserAgent(t *testing.T) {
 	}
 }
 
-// requireSetenv will os.Setenv the given key and value. The function returned reverts to the original.
-func requireSetenv(t *testing.T, key, value string) func() {
-	previous := os.Getenv(key)
-	err := os.Setenv(key, value)
-	require.NoError(t, err, `error setting env variable %s=%s`, key, value)
-	return func() {
-		err := os.Setenv(key, previous)
-		require.NoError(t, err, `error reverting env variable %s=%s`, key, previous)
-	}
-}
-
 // newApp initializes a command with buffers for stdout and stderr.
 func newApp(o *globals.GlobalOpts) (c *cli.App, stdout, stderr *bytes.Buffer) {
 	stdout = new(bytes.Buffer)
@@ -244,6 +233,7 @@ func runTestCommand(t *testing.T, o *globals.GlobalOpts, args []string) error {
 // The tear-down functions reverts side-effects such as temp directories and a fake Envoy versions server.
 func setupTest(t *testing.T) (*globals.GlobalOpts, func()) {
 	result := globals.GlobalOpts{}
+	result.HomeEnvoyVersion = version.LastKnownEnvoy
 	result.Out = io.Discard // ignore logging by default
 	var tearDown []func()
 

--- a/internal/cmd/app_test.go
+++ b/internal/cmd/app_test.go
@@ -233,7 +233,7 @@ func runTestCommand(t *testing.T, o *globals.GlobalOpts, args []string) error {
 // The tear-down functions reverts side-effects such as temp directories and a fake Envoy versions server.
 func setupTest(t *testing.T) (*globals.GlobalOpts, func()) {
 	result := globals.GlobalOpts{}
-	result.HomeEnvoyVersion = version.LastKnownEnvoy
+	result.EnvoyVersion = version.LastKnownEnvoy
 	result.Out = io.Discard // ignore logging by default
 	var tearDown []func()
 

--- a/internal/cmd/help_test.go
+++ b/internal/cmd/help_test.go
@@ -32,9 +32,9 @@ func TestGetEnvoyHelp(t *testing.T) {
 		command := command
 		t.Run(command, func(t *testing.T) {
 			c, stdout, _ := newApp(&globals.GlobalOpts{})
-			args := []string{"getenvoy", "-h"}
+			args := []string{"getenvoy"}
 			if command != "" {
-				args = []string{"getenvoy", command, "-h"}
+				args = []string{"getenvoy", "help", command}
 			}
 			require.NoError(t, c.Run(args))
 

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -31,7 +31,7 @@ func NewInstallCmd(o *globals.GlobalOpts) *cli.Command {
 		Usage:     "Download and install a [version] of Envoy",
 		ArgsUsage: "[version]",
 		Description: fmt.Sprintf(`The '[version]' is from the "versions" command.
-The Envoy <version> will be installed into $GETENVOY_HOME/versions/[version]
+The Envoy [version] will be installed into $GETENVOY_HOME/versions/[version]
 
 Example:
 $ getenvoy install %s`, version.LastKnownEnvoy),
@@ -45,11 +45,11 @@ $ getenvoy install %s`, version.LastKnownEnvoy),
 
 func validateVersionArg(c *cli.Context) error {
 	if c.NArg() == 0 {
-		return NewValidationError("missing <version> argument")
+		return NewValidationError("missing [version] argument")
 	}
 	v := c.Args().First()
 	if matched := globals.EnvoyVersionPattern.MatchString(v); !matched {
-		return NewValidationError("invalid <version> argument: %q should look like %q", v, version.LastKnownEnvoy)
+		return NewValidationError("invalid [version] argument: %q should look like %q", v, version.LastKnownEnvoy)
 	}
 	return nil
 }

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -28,10 +28,10 @@ import (
 func NewInstallCmd(o *globals.GlobalOpts) *cli.Command {
 	return &cli.Command{
 		Name:      "install",
-		Usage:     "Download and install a <version> of Envoy",
-		ArgsUsage: "<version>",
-		Description: fmt.Sprintf(`The '<version>' is from the "versions" command.
-The Envoy <version> will be installed into $GETENVOY_HOME/versions/<version>
+		Usage:     "Download and install a [version] of Envoy",
+		ArgsUsage: "[version]",
+		Description: fmt.Sprintf(`The '[version]' is from the "versions" command.
+The Envoy <version> will be installed into $GETENVOY_HOME/versions/[version]
 
 Example:
 $ getenvoy install %s`, version.LastKnownEnvoy),
@@ -41,4 +41,15 @@ $ getenvoy install %s`, version.LastKnownEnvoy),
 			return err
 		},
 	}
+}
+
+func validateVersionArg(c *cli.Context) error {
+	if c.NArg() == 0 {
+		return NewValidationError("missing <version> argument")
+	}
+	v := c.Args().First()
+	if matched := globals.EnvoyVersionPattern.MatchString(v); !matched {
+		return NewValidationError("invalid <version> argument: %q should look like %q", v, version.LastKnownEnvoy)
+	}
+	return nil
 }

--- a/internal/cmd/install_test.go
+++ b/internal/cmd/install_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Tetrate
+// Copyright 2021 Tetrate
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,12 +30,12 @@ func TestGetEnvoyInstall_VersionValidates(t *testing.T) {
 	tests := []struct{ name, version, expectedErr string }{
 		{
 			name:        "version empty",
-			expectedErr: fmt.Sprintf(`invalid <version> argument: "" should look like "%s"`, version.LastKnownEnvoy),
+			expectedErr: fmt.Sprintf(`invalid [version] argument: "" should look like "%s"`, version.LastKnownEnvoy),
 		},
 		{
 			name:        "version invalid",
 			version:     "a.b.c",
-			expectedErr: fmt.Sprintf(`invalid <version> argument: "a.b.c" should look like "%s"`, version.LastKnownEnvoy),
+			expectedErr: fmt.Sprintf(`invalid [version] argument: "a.b.c" should look like "%s"`, version.LastKnownEnvoy),
 		},
 	}
 

--- a/internal/cmd/install_test.go
+++ b/internal/cmd/install_test.go
@@ -1,0 +1,56 @@
+// Copyright 2020 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/getenvoy/internal/version"
+)
+
+func TestGetEnvoyInstall_VersionValidates(t *testing.T) {
+	o, cleanup := setupTest(t)
+	defer cleanup()
+
+	tests := []struct{ name, version, expectedErr string }{
+		{
+			name:        "version empty",
+			expectedErr: fmt.Sprintf(`invalid <version> argument: "" should look like "%s"`, version.LastKnownEnvoy),
+		},
+		{
+			name:        "version invalid",
+			version:     "a.b.c",
+			expectedErr: fmt.Sprintf(`invalid <version> argument: "a.b.c" should look like "%s"`, version.LastKnownEnvoy),
+		},
+	}
+
+	for _, test := range tests {
+		test := test // pin! see https://github.com/kyoh86/scopelint for why
+
+		t.Run(test.name, func(t *testing.T) {
+			c, stdout, stderr := newApp(o)
+			err := c.Run([]string{"getenvoy", "install", test.version})
+
+			// Verify the command failed with the expected error
+			require.EqualError(t, err, test.expectedErr)
+			// GetEnvoy handles logging of errors, so we expect nothing in stdout or stderr
+			require.Empty(t, stdout)
+			require.Empty(t, stderr)
+		})
+	}
+}

--- a/internal/cmd/testdata/getenvoy.md
+++ b/internal/cmd/testdata/getenvoy.md
@@ -8,7 +8,6 @@ getenvoy
 
 ```
 [--envoy-versions-url]=[value]
-[--help|-h]
 [--home-dir]=[value]
 [--version|-v]
 ```
@@ -23,8 +22,6 @@ getenvoy [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--envoy-versions-url**="": URL of Envoy versions JSON
 
-**--help, -h**: show help
-
 **--home-dir**="": GetEnvoy home directory (location of installed versions and run archives)
 
 **--version, -v**: print the version
@@ -32,9 +29,13 @@ getenvoy [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 # COMMANDS
 
+## help
+
+Shows how to use a [command]
+
 ## run
 
-Run Envoy as <version> with <args> as arguments, collecting process state on termination
+Run Envoy with the given [arguments...], collecting process state on termination
 
 ## versions
 
@@ -42,7 +43,7 @@ List available Envoy versions
 
 ## install
 
-Download and install a <version> of Envoy
+Download and install a [version] of Envoy
 
 ## installed
 

--- a/internal/cmd/testdata/getenvoy_help.txt
+++ b/internal/cmd/testdata/getenvoy_help.txt
@@ -8,13 +8,13 @@ VERSION:
    dev
 
 COMMANDS:
-   run        Run Envoy as <version> with <args> as arguments, collecting process state on termination
+   help       Shows how to use a [command]
+   run        Run Envoy with the given [arguments...], collecting process state on termination
    versions   List available Envoy versions
-   install    Download and install a <version> of Envoy
+   install    Download and install a [version] of Envoy
    installed  List installed Envoy versions
 
 GLOBAL OPTIONS:
    --home-dir value            GetEnvoy home directory (location of installed versions and run archives) (default: ${HOME}/.getenvoy) [$GETENVOY_HOME]
    --envoy-versions-url value  URL of Envoy versions JSON (default: https://getenvoy.io/envoy-versions.json) [$ENVOY_VERSIONS_URL]
-   --help, -h                  show help (default: false)
    --version, -v               print the version (default: false)

--- a/internal/cmd/testdata/getenvoy_install_help.txt
+++ b/internal/cmd/testdata/getenvoy_install_help.txt
@@ -6,7 +6,7 @@ USAGE:
 
 DESCRIPTION:
    The '[version]' is from the "versions" command.
-   The Envoy <version> will be installed into $GETENVOY_HOME/versions/[version]
+   The Envoy [version] will be installed into $GETENVOY_HOME/versions/[version]
    
    Example:
    $ getenvoy install 1.18.3

--- a/internal/cmd/testdata/getenvoy_install_help.txt
+++ b/internal/cmd/testdata/getenvoy_install_help.txt
@@ -1,16 +1,12 @@
 NAME:
-   getenvoy install - Download and install a <version> of Envoy
+   getenvoy install - Download and install a [version] of Envoy
 
 USAGE:
-   getenvoy install [command options] <version>
+   getenvoy install [version]
 
 DESCRIPTION:
-   The '<version>' is from the "versions" command.
-   The Envoy <version> will be installed into $GETENVOY_HOME/versions/<version>
+   The '[version]' is from the "versions" command.
+   The Envoy <version> will be installed into $GETENVOY_HOME/versions/[version]
    
    Example:
-   $ getenvoy install {ENVOY_VERSION}
-
-OPTIONS:
-   --help, -h  show help (default: false)
-   
+   $ getenvoy install 1.18.3

--- a/internal/cmd/testdata/getenvoy_installed_help.txt
+++ b/internal/cmd/testdata/getenvoy_installed_help.txt
@@ -2,8 +2,4 @@ NAME:
    getenvoy installed - List installed Envoy versions
 
 USAGE:
-   getenvoy installed [command options] [arguments...]
-
-OPTIONS:
-   --help, -h  show help (default: false)
-   
+   getenvoy installed [arguments...]

--- a/internal/cmd/testdata/getenvoy_run_help.txt
+++ b/internal/cmd/testdata/getenvoy_run_help.txt
@@ -1,17 +1,15 @@
 NAME:
-   getenvoy run - Run Envoy as <version> with <args> as arguments, collecting process state on termination
+   getenvoy run - Run Envoy with the given [arguments...], collecting process state on termination
 
 USAGE:
-   getenvoy run [command options] <version> <args>
+   getenvoy run [arguments...]
 
 DESCRIPTION:
-   The '<version>' is from the "versions" command and installed if necessary.
-   The '<args>' are interpreted by Envoy.
-   The Envoy working directory is archived as $GETENVOY_HOME/runs/$epochtime.tar.gz upon termination.
+   The version of Envoy run is chosen from $ENVOY_VERSION, $PWD/.envoy-version, $GETENVOY_HOME/version
+   The '[arguments...]' are interpreted by Envoy.
+   
+   Envoy uses $GETENVOY_HOME/runs/$epochtime as the working directory.
+   Upon termination, this is archived as $GETENVOY_HOME/runs/$epochtime.tar.gz.
    
    Example:
-   $ getenvoy run {ENVOY_VERSION} --config-path ./bootstrap.yaml
-
-OPTIONS:
-   --help, -h  show help (default: false)
-   
+   $ getenvoy run -c ./bootstrap.yaml

--- a/internal/cmd/testdata/getenvoy_versions_help.txt
+++ b/internal/cmd/testdata/getenvoy_versions_help.txt
@@ -2,8 +2,4 @@ NAME:
    getenvoy versions - List available Envoy versions
 
 USAGE:
-   getenvoy versions [command options] [arguments...]
-
-OPTIONS:
-   --help, -h  show help (default: false)
-   
+   getenvoy versions [arguments...]

--- a/internal/envoy/version.go
+++ b/internal/envoy/version.go
@@ -45,7 +45,7 @@ func CurrentVersion(homeVersion string) (string, string, error) {
 }
 
 func getCurrentVersion(homeVersion string) (v, source string, err error) {
-	// Priority 3: $ENVOY_VERSION
+	// Priority 1: $ENVOY_VERSION
 	source = versionVarName
 	if v = os.Getenv("ENVOY_VERSION"); v != "" {
 		return
@@ -62,7 +62,7 @@ func getCurrentVersion(homeVersion string) (v, source string, err error) {
 		return
 	}
 
-	// Priority 3: $GETENVOY_HOME/versions
+	// Priority 3: $GETENVOY_HOME/version
 	source = homeVersionFileName
 	v = homeVersion
 	err = nil

--- a/internal/envoy/version.go
+++ b/internal/envoy/version.go
@@ -30,10 +30,8 @@ var (
 	currentVersionHomeDirFile    = filepath.Join("$GETENVOY_HOME", "version")
 )
 
-// GetHomeVersion returns the default version in the "$GETENVOY_HOME" file and path to to it (homeVersionFile).
-// When "v" is empty, homeVersionFile is not yet initialized.
-//
-// If an error is returned, it includes the unexpanded "$GETENVOY_HOME" variable to clarify the intended context.
+// GetHomeVersion returns the default version in the "homeDir" and path to to it (homeVersionFile). When "v" is empty,
+// homeVersionFile is not yet initialized.
 func GetHomeVersion(homeDir string) (v, homeVersionFile string, err error) {
 	v, homeVersionFile, err = getHomeVersion(homeDir)
 	if err == nil && v == "" { // no home version, yet

--- a/internal/envoy/version.go
+++ b/internal/envoy/version.go
@@ -46,27 +46,20 @@ func CurrentVersion(homeVersion string) (string, string, error) {
 
 func getCurrentVersion(homeVersion string) (v, source string, err error) {
 	// Priority 1: $ENVOY_VERSION
-	source = versionVarName
-	if v = os.Getenv("ENVOY_VERSION"); v != "" {
-		return
+	if v, ok := os.LookupEnv("ENVOY_VERSION"); ok {
+		return v, versionSourceVersionVar, nil
 	}
 
 	// Priority 2: $PWD/.envoy-version
-	source = wdVersionFileName
-	var data []byte
-	data, err = os.ReadFile(".envoy-version")
+	data, err := os.ReadFile(".envoy-version")
 	if err == nil {
-		v = string(data)
-		return
+		return string(data), versionSourceWDVersionFile, nil
 	} else if !os.IsNotExist(err) {
-		return
+		return "", "", err
 	}
 
 	// Priority 3: $GETENVOY_HOME/version
-	source = homeVersionFileName
-	v = homeVersion
-	err = nil
-	return
+	return homeVersion, versionSourceHomeVersionFile, nil
 }
 
 // VersionUsageList is the priority order of Envoy version sources.

--- a/internal/envoy/version.go
+++ b/internal/envoy/version.go
@@ -1,0 +1,76 @@
+// Copyright 2021 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tetratelabs/getenvoy/internal/globals"
+	"github.com/tetratelabs/getenvoy/internal/version"
+)
+
+var (
+	versionVarName      = "$ENVOY_VERSION"
+	wdVersionFileName   = filepath.Join("$PWD", ".envoy-version")
+	homeVersionFileName = filepath.Join("$GETENVOY_HOME", "version")
+)
+
+// CurrentVersion returns the first version in priority of VersionUsageList and its source or an error.
+func CurrentVersion(homeVersion string) (string, string, error) {
+	v, source, err := getCurrentVersion(homeVersion)
+	if err != nil {
+		return "", "", fmt.Errorf("couldn't read version from %s: %w", source, err)
+	}
+
+	if matched := globals.EnvoyVersionPattern.MatchString(v); !matched {
+		return "", "", fmt.Errorf("invalid version in %q: %q should look like %q", source, v, version.LastKnownEnvoy)
+	}
+
+	return v, source, err
+}
+
+func getCurrentVersion(homeVersion string) (v, source string, err error) {
+	// Priority 3: $ENVOY_VERSION
+	source = versionVarName
+	if v = os.Getenv("ENVOY_VERSION"); v != "" {
+		return
+	}
+
+	// Priority 2: $PWD/.envoy-version
+	source = wdVersionFileName
+	var data []byte
+	data, err = os.ReadFile(".envoy-version")
+	if err == nil {
+		v = string(data)
+		return
+	} else if !os.IsNotExist(err) {
+		return
+	}
+
+	// Priority 3: $GETENVOY_HOME/versions
+	source = homeVersionFileName
+	v = homeVersion
+	err = nil
+	return
+}
+
+// VersionUsageList is the priority order of Envoy version sources.
+// This includes unresolved variables as it is both used statically for markdown generation, and also at runtime.
+func VersionUsageList() string {
+	return strings.Join([]string{versionVarName, wdVersionFileName, homeVersionFileName}, ", ")
+}

--- a/internal/envoy/version.go
+++ b/internal/envoy/version.go
@@ -25,9 +25,9 @@ import (
 )
 
 var (
-	versionVarName      = "$ENVOY_VERSION"
-	wdVersionFileName   = filepath.Join("$PWD", ".envoy-version")
-	homeVersionFileName = filepath.Join("$GETENVOY_HOME", "version")
+	versionSourceVersionVar      = "$ENVOY_VERSION"
+	versionSourceWDVersionFile   = filepath.Join("$PWD", ".envoy-version")
+	versionSourceHomeVersionFile = filepath.Join("$GETENVOY_HOME", "version")
 )
 
 // CurrentVersion returns the first version in priority of VersionUsageList and its source or an error.

--- a/internal/envoy/version_test.go
+++ b/internal/envoy/version_test.go
@@ -1,0 +1,106 @@
+// Copyright 2021 Tetrate
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tetratelabs/getenvoy/internal/test/morerequire"
+	"github.com/tetratelabs/getenvoy/internal/version"
+)
+
+func TestVersionUsageList(t *testing.T) {
+	require.Equal(t, "$ENVOY_VERSION, $PWD/.envoy-version, $GETENVOY_HOME/version", VersionUsageList())
+}
+
+func TestCurrentVersion(t *testing.T) {
+	homeVersion := "1.1.1"
+
+	t.Run("defaults to home version", func(t *testing.T) {
+		v, source, err := CurrentVersion(homeVersion)
+		require.Equal(t, "1.1.1", v)
+		require.Equal(t, "$GETENVOY_HOME/version", source)
+		require.NoError(t, err)
+	})
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(wd) //nolint
+
+	tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
+	defer removeTempDir()
+	require.NoError(t, os.Chdir(tempDir))
+	require.NoError(t, os.WriteFile(".envoy-version", []byte("2.2.2"), 0600))
+
+	t.Run("prefers $PWD/.envoy-version over home version", func(t *testing.T) {
+		v, source, err := CurrentVersion(homeVersion)
+		require.Equal(t, "2.2.2", v)
+		require.Equal(t, "$PWD/.envoy-version", source)
+		require.NoError(t, err)
+	})
+
+	revert := morerequire.RequireSetenv(t, "ENVOY_VERSION", "3.3.3")
+	defer revert()
+
+	t.Run("prefers $ENVOY_VERSION over $PWD/.envoy-version", func(t *testing.T) {
+		v, source, err := CurrentVersion(homeVersion)
+		require.Equal(t, "3.3.3", v)
+		require.Equal(t, "$ENVOY_VERSION", source)
+		require.NoError(t, err)
+	})
+}
+
+func TestCurrentVersion_Validates(t *testing.T) {
+	homeVersion := "a.a.a"
+
+	t.Run("validates home version", func(t *testing.T) {
+		_, _, err := CurrentVersion(homeVersion)
+		require.EqualError(t, err, fmt.Sprintf(`invalid version in "$GETENVOY_HOME/version": "a.a.a" should look like "%s"`, version.LastKnownEnvoy))
+	})
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(wd) //nolint
+
+	tempDir, removeTempDir := morerequire.RequireNewTempDir(t)
+	defer removeTempDir()
+	require.NoError(t, os.Chdir(tempDir))
+	require.NoError(t, os.WriteFile(".envoy-version", []byte("b.b.b"), 0600))
+
+	t.Run("validates $PWD/.envoy-version", func(t *testing.T) {
+		_, _, err := CurrentVersion(homeVersion)
+		require.EqualError(t, err, fmt.Sprintf(`invalid version in "$PWD/.envoy-version": "b.b.b" should look like "%s"`, version.LastKnownEnvoy))
+	})
+
+	require.NoError(t, os.Remove(".envoy-version"))
+	require.NoError(t, os.Mkdir(".envoy-version", 0700))
+
+	t.Run("shows error reading $PWD/.envoy-version", func(t *testing.T) {
+		_, _, err := CurrentVersion(homeVersion)
+		require.Contains(t, err.Error(), "couldn't read version from $PWD/.envoy-version")
+	})
+
+	revert := morerequire.RequireSetenv(t, "ENVOY_VERSION", "c.c.c")
+	defer revert()
+
+	t.Run("validates $ENVOY_VERSION", func(t *testing.T) {
+		_, _, err := CurrentVersion(homeVersion)
+		require.EqualError(t, err, fmt.Sprintf(`invalid version in "$ENVOY_VERSION": "c.c.c" should look like "%s"`, version.LastKnownEnvoy))
+	})
+}

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -47,9 +47,9 @@ type GlobalOpts struct {
 	RunOpts
 	// EnvoyVersionsURL is the path to the envoy-versions.json. Defaults to DefaultEnvoyVersionsURL
 	EnvoyVersionsURL string
-	// HomeEnvoyVersion is the default version of Envoy to run. Defaults to the contents of "$HomeDir/versions/version".
+	// EnvoyVersion is the default version of Envoy to run. Defaults to the contents of "$HomeDir/versions/version".
 	// When that file is missing, it is generated from ".latestVersion" from the EnvoyVersionsURL.
-	HomeEnvoyVersion string
+	EnvoyVersion string
 	// HomeDir is an absolute path which most importantly contains "versions" installed from EnvoyVersionsURL. Defaults to DefaultHomeDir
 	HomeDir string
 	// UserAgent is the "User-Agent" header added to all HTTP requests. Defaults to DefaultUserAgent

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -17,6 +17,7 @@ package globals
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"runtime"
 
 	"github.com/tetratelabs/getenvoy/internal/version"
@@ -46,7 +47,10 @@ type GlobalOpts struct {
 	RunOpts
 	// EnvoyVersionsURL is the path to the envoy-versions.json. Defaults to DefaultEnvoyVersionsURL
 	EnvoyVersionsURL string
-	// HomeDir most importantly contains Envoy versions installed from EnvoyVersionsURL. Defaults to DefaultHomeDir
+	// HomeEnvoyVersion is the default version of Envoy to run. Defaults to the contents of "$HomeDir/versions/version".
+	// When that file is missing, it is generated from ".latestVersion" from the EnvoyVersionsURL.
+	HomeEnvoyVersion string
+	// HomeDir is an absolute path which most importantly contains "versions" installed from EnvoyVersionsURL. Defaults to DefaultHomeDir
 	HomeDir string
 	// UserAgent is the "User-Agent" header added to all HTTP requests. Defaults to DefaultUserAgent
 	UserAgent string
@@ -62,6 +66,8 @@ const (
 )
 
 var (
+	// EnvoyVersionPattern is used to validate versions and is the same pattern as envoy-versions-schema.json.
+	EnvoyVersionPattern = regexp.MustCompile(`^[1-9][0-9]*\.[0-9]+\.[0-9]+$`)
 	// CurrentPlatform is the platform of the current process. This is used as a key in EnvoyVersion.Tarballs.
 	CurrentPlatform = runtime.GOOS + "/" + runtime.GOARCH
 	// DefaultUserAgent is the default value for GlobalOpts.UserAgent.

--- a/internal/test/morerequire/morerequire.go
+++ b/internal/test/morerequire/morerequire.go
@@ -49,3 +49,14 @@ var (
 func RequireCaptureScript(t *testing.T, path string) {
 	require.NoError(t, os.WriteFile(path, captureScript, 0700)) //nolint:gosec
 }
+
+// RequireSetenv will os.Setenv the given key and value. The function returned reverts to the original.
+func RequireSetenv(t *testing.T, key, value string) func() {
+	previous := os.Getenv(key)
+	err := os.Setenv(key, value)
+	require.NoError(t, err, `error setting env variable %s=%s`, key, value)
+	return func() {
+		err := os.Setenv(key, previous)
+		require.NoError(t, err, `error reverting env variable %s=%s`, key, previous)
+	}
+}

--- a/internal/test/morerequire/morerequire.go
+++ b/internal/test/morerequire/morerequire.go
@@ -56,7 +56,11 @@ func RequireSetenv(t *testing.T, key, value string) func() {
 	err := os.Setenv(key, value)
 	require.NoError(t, err, `error setting env variable %s=%s`, key, value)
 	return func() {
-		err := os.Setenv(key, previous)
+		if previous != "" {
+			err = os.Setenv(key, previous)
+		} else {
+			err = os.Unsetenv(key)
+		}
 		require.NoError(t, err, `error reverting env variable %s=%s`, key, previous)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -57,5 +57,5 @@ func run(stdout, stderr io.Writer, args []string) int {
 }
 
 func logUsageError(name string, stderr io.Writer) {
-	fmt.Fprintln(stderr, "show usage with:", name, "-h") //nolint
+	fmt.Fprintln(stderr, "show usage with:", name, "help") //nolint
 }

--- a/main_test.go
+++ b/main_test.go
@@ -47,7 +47,7 @@ func TestRunErrors(t *testing.T) {
 			args:           []string{"getenvoy", "--d"},
 			expectedStatus: 1,
 			expectedStderr: `flag provided but not defined: -d
-show usage with: getenvoy -h
+show usage with: getenvoy help
 `,
 		},
 		{
@@ -55,7 +55,7 @@ show usage with: getenvoy -h
 			args:           []string{"getenvoy", "--envoy-versions-url", ".", "list"},
 			expectedStatus: 1,
 			expectedStderr: `"." is not a valid Envoy versions URL
-show usage with: getenvoy -h
+show usage with: getenvoy help
 `,
 		},
 		{
@@ -63,7 +63,7 @@ show usage with: getenvoy -h
 			args:           []string{"getenvoy", "fly"},
 			expectedStatus: 1,
 			expectedStderr: `unknown command "fly"
-show usage with: getenvoy -h
+show usage with: getenvoy help
 `,
 		},
 		{


### PR DESCRIPTION
This removes the version argument so that you can `getenvoy run`
without knowing which version you want first.

Ex.
```bash
$ getenvoy run --config-yaml "admin: {access_log_path: '/dev/stdout', address: {socket_address: {address: '127.0.0.1', port_value: 0}}}"
looking up latest version
downloading https://dl.getenvoy.io/public/raw/files/getenvoy-envoy-1.18.3.p0.g98c1c9e-1p77.gb76c773-darwin-release-x86_64.tar.xz
--snip--
```

The version of Envoy run is chosen from $ENVOY_VERSION (value),
$PWD/.envoy-version (file contents), $GETENVOY_HOME/version (file
contents).

The ENV allows people who really want to control the version to do so,
and without effecting the arg parsing of `envoy`.

When first run $GETENVOY_HOME/version is initialized the the remote
version stored as "lastestVersion" in the envoy-versions.json file.
Specifically, that's here: https://getenvoy.io/envoy-versions.json

To ensure arguments don't interfere (ex. envoy also has a '-h'), this
removes the '-h' argument from `getenvoy`, replaced with a `help`
command that is run by default and can be command-scoped.

Ex. `getenvoy` or `getenvoy help` show help, and `getenvoy help run` is
scoped as you'd expect.

Fixes #106