### PR TITLE
Fixes release test

### DIFF
--- a/.github/untar-getenvoy-release.sh
+++ b/.github/untar-getenvoy-release.sh
@@ -6,6 +6,7 @@
 # Crash early on any missing prerequisites
 tag_name=$1
 curl --version >/dev/null
+go version >/dev/null
 jq --version >/dev/null
 tar --version >/dev/null
 
@@ -13,8 +14,7 @@ tar --version >/dev/null
 version=$(echo "${tag_name}" | cut -c2-100) || exit 1
 
 # form the asset name you'd find on the release page
-os_arch=$(go env GOOS)_$(go env GOARCH) || exit 1
-tarball=getenvoy_${version}_${os_arch}.tar.gz
+tarball="getenvoy_${version}_$(go env GOOS)_$(go env GOARCH).tar.gz" || exit 1
 
 # Lookup the last 10 releases, knowing the one we are looking for may not be published.
 # See https://docs.github.com/en/rest/reference/repos#list-releases

--- a/.github/untar-getenvoy-release.sh
+++ b/.github/untar-getenvoy-release.sh
@@ -1,0 +1,28 @@
+#!/bin/sh -ue
+#
+# This script extracts "getenvoy" for a specific release tag. The release can be a draft.
+# Ex. GITHUB_TOKEN=your_repo_token .github/untar-getenvoy-release.sh v0.3.0
+
+# Crash early on any missing prerequisites
+tag_name=$1
+curl --version >/dev/null
+jq --version >/dev/null
+tar --version >/dev/null
+
+# strip the v off the tag name more shell portable than ${tag_name:1}
+version=$(echo "${tag_name}" | cut -c2-100) || exit 1
+
+# form the asset name you'd find on the release page
+os_arch=$(go env GOOS)_$(go env GOARCH) || exit 1
+tarball=getenvoy_${version}_${os_arch}.tar.gz
+
+# Lookup the last 10 releases, knowing the one we are looking for may not be published.
+# See https://docs.github.com/en/rest/reference/repos#list-releases
+echo "looking for release that contains ${tarball}"
+tarball_url=$(curl -sSL -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/tetratelabs/getenvoy/releases?per_page=10 |
+  jq -er ".|first|.assets| map(select(.name == \"${tarball}\"))|first|.url") || exit 1
+
+# Extract getenvoy to the CWD per https://docs.github.com/en/rest/reference/repos#get-a-release-asset
+echo "extracting getenvoy from ${tarball_url}"
+curl -sSL -H "Authorization: token ${GITHUB_TOKEN}" -H'Accept: application/octet-stream' "${tarball_url}" | tar -xzf - getenvoy
+./getenvoy -version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: "Download `getenvoy` binary from GitHub release assets"
+      - name: "Extract `getenvoy` binary from GitHub release assets"
         run: .github/untar-getenvoy-release.sh ${GITHUB_REF#refs/*/}
         env:  # authenticate as the release is a draft
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,23 +52,10 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: "Get tag name"
-        run: | # Trim "v" prefix in the release tag
-          RELEASE_TAG=${GITHUB_REF#refs/*/}
-          if [[ "${RELEASE_TAG}" = v* ]]; then RELEASE_VERSION="${RELEASE_TAG:1}"; else RELEASE_VERSION="${RELEASE_TAG}"; fi
-          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> $GITHUB_ENV
-          echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
-          echo "OS_ARCH=$(go env GOOS)_$(go env GOARCH)" >> $GITHUB_ENV
-
       - name: "Download `getenvoy` binary from GitHub release assets"
-        env:
-          INPUT_FILE: getenvoy_${{ env.RELEASE_VERSION }}_${{ env.OS_ARCH }}.tar.gz
-          INPUT_VERSION: tags/${{ env.RELEASE_TAG }}
-        run: |  # extract getenvoy to location used in `make e2e`. don't chmod because tar.gz should be correct.
-          curl -s https://raw.githubusercontent.com/dsaltares/fetch-gh-release-asset/0.06/fetch_github_asset.sh | bash
-          dir=dist/getenvoy_${{ env.OS_ARCH }}
-          mkdir -p $dir
-          tar -C $dir -xf ${INPUT_FILE} getenvoy
+        run: .github/untar-getenvoy-release.sh ${GITHUB_REF#refs/*/}
+        env:  # authenticate as the release is a draft
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Run e2e tests using released `getenvoy` binary"
-        run: make e2e
+        run: E2E_GETENVOY_BINARY=$PWD/getenvoy make e2e

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /.idea
 /coverage.txt
 /dist/
+
+# possible when testing .github/untar-getenvoy-release.sh
+getenvoy


### PR DESCRIPTION
The script we were using doesn't handle draft releases. This rewrites
the script so that we can test our binaries before announcing them via a
published release.