### PR TITLE
Runs Envoy in the current working directory

### DIFF
--- a/.licenserignore
+++ b/.licenserignore
@@ -16,3 +16,4 @@ last_known_envoy.txt
 
 testdata/
 site/*.json
+e2e/*.yaml

--- a/e2e/admin_test.go
+++ b/e2e/admin_test.go
@@ -70,7 +70,7 @@ func (c *adminClient) getJSON(path string, v interface{}) error {
 	return json.Unmarshal(body, v)
 }
 
-func get(url string) ([]byte, error) {
+func httpGet(url string) ([]byte, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err

--- a/e2e/admin_test.go
+++ b/e2e/admin_test.go
@@ -22,37 +22,20 @@ import (
 	"net/http"
 )
 
-// adminAPI represents Envoy Admin API.
-type adminAPI interface {
-	isReady() (bool, error)
-	getStats() (*stats, error)
-}
-
-// stats represents Envoy response to `/stats?format=json` endpoint.
-type stats struct {
-	Metrics []metric `json:"stats"`
-}
-
-// metric represents recorded value of a single metric.
-type metric struct {
-	Name  string  `json:"name"`
-	Value float64 `json:"value"`
-}
-
-// newClient returns a new client for Envoy Admin API.
-func newClient(address string) (adminAPI, error) {
+// newAdminClient returns a new client for Envoy Admin API.
+func newAdminClient(address string) (*adminClient, error) {
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, err
 	}
-	return &client{baseURL: fmt.Sprintf("http://%s:%s", host, port)}, nil
+	return &adminClient{baseURL: fmt.Sprintf("http://%s:%s", host, port)}, nil
 }
 
-type client struct {
+type adminClient struct {
 	baseURL string
 }
 
-func (c *client) isReady() (bool, error) {
+func (c *adminClient) isReady() (bool, error) {
 	resp, err := http.Get(c.baseURL + "/ready")
 	if err != nil {
 		return false, err
@@ -61,8 +44,34 @@ func (c *client) isReady() (bool, error) {
 	return resp.StatusCode == http.StatusOK, nil
 }
 
-func (c *client) getStats() (*stats, error) {
-	resp, err := http.Get(c.baseURL + "/stats?format=json")
+func (c *adminClient) getMainListenerURL() (string, error) {
+	var s map[string]interface{}
+	if err := c.getJSON("/listeners", &s); err != nil {
+		return "", err
+	}
+
+	// The json structure is deep, so parsing instead of many nested structs
+	for _, s := range s["listener_statuses"].([]interface{}) {
+		l := s.(map[string]interface{})
+		if l["name"] != "main" {
+			continue
+		}
+		port := l["local_address"].(map[string]interface{})["socket_address"].(map[string]interface{})["port_value"]
+		return fmt.Sprintf("http://127.0.0.1:%d", int(port.(float64))), nil
+	}
+	return "", fmt.Errorf("didn't find main port in %+v", s)
+}
+
+func (c *adminClient) getJSON(path string, v interface{}) error {
+	body, err := get(c.baseURL + path + "?format=json")
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(body, v)
+}
+
+func get(url string) ([]byte, error) {
+	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err
 	}
@@ -70,14 +79,5 @@ func (c *client) getStats() (*stats, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	var s stats
-	err = json.Unmarshal(body, &s)
-	if err != nil {
-		return nil, err
-	}
-	return &s, nil
+	return io.ReadAll(resp.Body)
 }

--- a/e2e/admin_test.go
+++ b/e2e/admin_test.go
@@ -63,7 +63,7 @@ func (c *adminClient) getMainListenerURL() (string, error) {
 }
 
 func (c *adminClient) getJSON(path string, v interface{}) error {
-	body, err := get(c.baseURL + path + "?format=json")
+	body, err := httpGet(c.baseURL + path + "?format=json")
 	if err != nil {
 		return err
 	}

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -40,11 +40,6 @@ func getEnvoy(args ...string) *cmdBuilder { //nolint:golint
 	return &cmdBuilder{exec.Command(getEnvoyPath, args...)} //nolint:gosec
 }
 
-func (b *cmdBuilder) args(args ...string) *cmdBuilder {
-	b.cmd.Args = append(b.cmd.Args, args...)
-	return b
-}
-
 func (b *cmdBuilder) String() string {
 	return fmt.Sprintf("%s: %s", b.cmd.Dir, strings.Join(b.cmd.Args, " "))
 }

--- a/e2e/getenvoy_run_test.go
+++ b/e2e/getenvoy_run_test.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	_ "embed" // We embed the config files to make them easier to copy
 	"io"
 	"log"
 	"os"
@@ -26,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/tetratelabs/getenvoy/internal/tar"
+	"github.com/tetratelabs/getenvoy/internal/test/morerequire"
 )
 
 const terminateTimeout = 2 * time.Minute
@@ -36,9 +38,8 @@ const terminateTimeout = 2 * time.Minute
 func TestGetEnvoyRun(t *testing.T) {
 	t.Parallel() // uses random ports so safe to run parallel
 
-	c := getEnvoy(`run`)
 	// Below is the minimal config needed to run envoy
-	c.args("--config-yaml", "admin: {access_log_path: '/dev/stdout', address: {socket_address: {address: '127.0.0.1', port_value: 0}}}")
+	c := getEnvoy(`run`, "--config-yaml", "admin: {access_log_path: '/dev/stdout', address: {socket_address: {address: '127.0.0.1', port_value: 0}}}")
 
 	stdout, stderr, terminate := c.start(t, terminateTimeout)
 
@@ -50,43 +51,74 @@ func TestGetEnvoyRun(t *testing.T) {
 		}
 	}()
 
-	envoyWorkingDir := requireEnvoyWorkingDir(t, stdout, c)
-	requireEnvoyReady(t, envoyWorkingDir, stderr, c)
+	runDir := requireRunDir(t, stdout, c)
+	requireEnvoyReady(t, runDir, stderr, c)
 
 	log.Printf(`stopping Envoy after running [%v]`, c)
 	terminate()
 	deferredTerminate = nil
 
-	verifyDebugDump(t, envoyWorkingDir, c)
+	verifyDebugDump(t, runDir, c)
 }
 
-func requireEnvoyWorkingDir(t *testing.T, stdout io.Reader, c interface{}) string {
+// staticFilesystemConfig shows envoy reading a file referenced from the CWD
+//go:embed static-filesystem.yaml
+var staticFilesystemConfig []byte
+
+func TestGetEnvoyRun_StaticFilesystem(t *testing.T) {
+	t.Parallel() // uses random ports so safe to run parallel
+
+	revertTempWd := morerequire.RequireChdirIntoTemp(t)
+	defer revertTempWd()
+
+	require.NoError(t, os.WriteFile("envoy.yaml", staticFilesystemConfig, 0600))
+	responseFromWorkingDirectory := []byte("foo")
+	require.NoError(t, os.WriteFile("response.txt", responseFromWorkingDirectory, 0600))
+	c := getEnvoy(`run`, "-c", "envoy.yaml")
+
+	stdout, stderr, terminate := c.start(t, terminateTimeout)
+	defer terminate()
+
+	runDir := requireRunDir(t, stdout, c)
+	admin := requireEnvoyReady(t, runDir, stderr, c)
+
+	mainURL, err := admin.getMainListenerURL()
+	require.NoError(t, err, `couldn't read mainURL after running [%v]`, c)
+
+	body, err := get(mainURL)
+	require.NoError(t, err, `couldn't read %s after running [%v]`, mainURL, c)
+
+	// If this passes, we know Envoy is running in the current directory, so can resolve relative configuration.
+	require.Equal(t, responseFromWorkingDirectory, body, `unexpected content in %s after running [%v]`, mainURL, c)
+}
+
+func requireRunDir(t *testing.T, stdout io.Reader, c interface{}) string {
 	stdoutLines := streamLines(stdout).named("stdout")
-	log.Printf(`waiting for GetEnvoy to log working directory after running [%v]`, c)
-	workingDirectoryPattern := regexp.MustCompile(`working directory: (.*)`)
-	line, err := stdoutLines.FirstMatch(workingDirectoryPattern).Wait(1 * time.Minute)
-	require.NoError(t, err, `error parsing working directory from stdout of [%v]`, c)
-	return workingDirectoryPattern.FindStringSubmatch(line)[1]
+	log.Printf(`waiting for GetEnvoy to log admin address path after running [%v]`, c)
+	adminAddressPathPattern := regexp.MustCompile(`--admin-address-path ([^ ]+)`)
+	line, err := stdoutLines.FirstMatch(adminAddressPathPattern).Wait(1 * time.Minute)
+	require.NoError(t, err, `error parsing admin address path from stdout of [%v]`, c)
+	return filepath.Dir(adminAddressPathPattern.FindStringSubmatch(line)[1])
 }
 
-func requireEnvoyReady(t *testing.T, envoyWorkingDir string, stderr io.Reader, c interface{}) adminAPI {
+func requireEnvoyReady(t *testing.T, runDir string, stderr io.Reader, c interface{}) *adminClient {
 	stderrLines := streamLines(stderr).named("stderr")
 
 	log.Printf(`waiting for Envoy start-up to complete after running [%v]`, c)
 	_, err := stderrLines.FirstMatch(regexp.MustCompile(`starting main dispatch loop`)).Wait(1 * time.Minute)
 	require.NoError(t, err, `error parsing startup from stderr of [%v]`, c)
 
-	adminAddressPath := filepath.Join(envoyWorkingDir, "admin-address.txt")
+	adminAddressPath := filepath.Join(runDir, "admin-address.txt")
 	adminAddress, err := os.ReadFile(adminAddressPath) //nolint:gosec
 	require.NoError(t, err, `error reading admin address file %q after running [%v]`, adminAddressPath, c)
 
-	log.Printf(`waiting for Envoy client to connect after running [%v]`, c)
-	envoyClient, err := newClient(string(adminAddress))
-	require.NoError(t, err, `error from envoy client %s after running [%v]`, adminAddress, c)
+	log.Printf(`waiting for Envoy adminClient to connect after running [%v]`, c)
+	envoyClient, err := newAdminClient(string(adminAddress))
+	require.NoError(t, err, `error from envoy adminClient %s after running [%v]`, adminAddress, c)
 	require.Eventually(t, func() bool {
 		ready, err := envoyClient.isReady()
 		return err == nil && ready
-	}, 1*time.Minute, 100*time.Millisecond, `envoy client %s never ready after running [%v]`, adminAddress, c)
+	}, 1*time.Minute, 100*time.Millisecond, `envoy adminClient %s never ready after running [%v]`, adminAddress, c)
 
 	return envoyClient
 }

--- a/e2e/getenvoy_run_test.go
+++ b/e2e/getenvoy_run_test.go
@@ -85,7 +85,7 @@ func TestGetEnvoyRun_StaticFilesystem(t *testing.T) {
 	mainURL, err := admin.getMainListenerURL()
 	require.NoError(t, err, `couldn't read mainURL after running [%v]`, c)
 
-	body, err := get(mainURL)
+	body, err := httpGet(mainURL)
 	require.NoError(t, err, `couldn't read %s after running [%v]`, mainURL, c)
 
 	// If this passes, we know Envoy is running in the current directory, so can resolve relative configuration.

--- a/e2e/static-filesystem.yaml
+++ b/e2e/static-filesystem.yaml
@@ -1,0 +1,37 @@
+admin:
+  access_log_path: '/dev/stdout'
+  address:
+    socket_address:
+      address: '127.0.0.1'
+      port_value: 0
+
+static_resources:
+  listeners:
+    - name: main
+      address:
+        socket_address:
+          address: '127.0.0.1'
+          port_value: 0
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                codec_type: auto
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                          direct_response:
+                            status: 200
+                            body:
+                              filename: "response.txt"
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config: { }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -37,17 +37,16 @@ func NewRunCmd(o *globals.GlobalOpts) *cli.Command {
 		Usage:           "Run Envoy with the given [arguments...], collecting process state on termination",
 		ArgsUsage:       "[arguments...]",
 		SkipFlagParsing: true,
-		Description: fmt.Sprintf(`
-Envoy interprets the '[arguments...]'.
+		Description: `To run Envoy, execute ` + "`getenvoy run -c your_envoy_config.yaml`" + `. This
+downloads and installs the latest version of Envoy for you.
 
-The "use" command primarily controls the version. The first version in %s is
-run, installing on-demand as needed.
+Envoy runs in the current directory and interprets the '[arguments...]'.
+The first version in the below is run, controllable by the "use" command:
+` + fmt.Sprintf("```\n%s\n```", envoy.VersionUsageList()) + `
 
-Envoy uses $GETENVOY_HOME/runs/$epochtime as the working directory.
-Upon termination, this is archived as $GETENVOY_HOME/runs/$epochtime.tar.gz.
-
-Example:
-$ getenvoy run -c ./bootstrap.yaml`, envoy.VersionUsageList()),
+getenvoy generates files, e.g. logs, into ` + "`$GETENVOY_HOME/runs/$epochtime`" + `.
+These archive into ` + "`$GETENVOY_HOME/runs/$epochtime.tar.gz`" + ` upon termination.
+`,
 		Before: func(context *cli.Context) error {
 			if err := os.MkdirAll(o.HomeDir, 0750); err != nil {
 				return NewValidationError(err.Error())
@@ -97,16 +96,15 @@ func initializeRunOpts(o *globals.GlobalOpts, p, v string) error {
 		}
 		o.EnvoyPath = envoyPath
 	}
-	if runOpts.WorkingDir == "" { // not overridden for tests
-		// Historically, the directory run files wrote to was called DebugStore
+	if runOpts.RunDir == "" { // not overridden for tests
 		runID := strconv.FormatInt(time.Now().UnixNano(), 10)
-		workingDir := filepath.Join(filepath.Join(o.HomeDir, "runs"), runID)
+		runDir := filepath.Join(filepath.Join(o.HomeDir, "runs"), runID)
 
 		// When the directory is implicitly generated, we should create it to avoid late errors.
-		if err := os.MkdirAll(workingDir, 0750); err != nil {
-			return NewValidationError("unable to create working directory %q, so we cannot run envoy", workingDir)
+		if err := os.MkdirAll(runDir, 0750); err != nil {
+			return NewValidationError("unable to create working directory %q, so we cannot run envoy", runDir)
 		}
-		runOpts.WorkingDir = workingDir
+		runOpts.RunDir = runDir
 	}
 	return nil
 }

--- a/internal/cmd/testdata/getenvoy_run_help.txt
+++ b/internal/cmd/testdata/getenvoy_run_help.txt
@@ -5,13 +5,14 @@ USAGE:
    getenvoy run [arguments...]
 
 DESCRIPTION:
-   Envoy interprets the '[arguments...]'.
+   To run Envoy, execute `getenvoy run -c your_envoy_config.yaml`. This
+   downloads and installs the latest version of Envoy for you.
    
-   The "use" command primarily controls the version. The first version in $ENVOY_VERSION, $PWD/.envoy-version, $GETENVOY_HOME/version is
-   run, installing on-demand as needed.
+   Envoy runs in the current directory and interprets the '[arguments...]'.
+   The first version in the below is run, controllable by the "use" command:
+   ```
+   $ENVOY_VERSION, $PWD/.envoy-version, $GETENVOY_HOME/version
+   ```
    
-   Envoy uses $GETENVOY_HOME/runs/$epochtime as the working directory.
-   Upon termination, this is archived as $GETENVOY_HOME/runs/$epochtime.tar.gz.
-   
-   Example:
-   $ getenvoy run -c ./bootstrap.yaml
+   getenvoy generates files, e.g. logs, into `$GETENVOY_HOME/runs/$epochtime`.
+   These archive into `$GETENVOY_HOME/runs/$epochtime.tar.gz` upon termination.

--- a/internal/envoy/debug/admin.go
+++ b/internal/envoy/debug/admin.go
@@ -38,7 +38,7 @@ var adminAPIPaths = map[string]string{
 
 // enableEnvoyAdminDataCollection is a preset option that registers collection of Envoy Admin API information
 func enableEnvoyAdminDataCollection(r *envoy.Runtime) error {
-	e := envoyAdminDataCollection{r.GetAdminAddress, r.GetWorkingDir()}
+	e := envoyAdminDataCollection{r.GetAdminAddress, r.GetRunDir()}
 	r.RegisterPreTermination(e.retrieveAdminAPIData)
 	return nil
 }

--- a/internal/envoy/debug/log.go
+++ b/internal/envoy/debug/log.go
@@ -25,7 +25,7 @@ import (
 
 // enableEnvoyLogCollection is a preset option that registers collection of Envoy access logs and stderr
 func enableEnvoyLogCollection(r *envoy.Runtime) error {
-	logsDir := filepath.Join(r.GetWorkingDir(), "logs")
+	logsDir := filepath.Join(r.GetRunDir(), "logs")
 	if err := os.MkdirAll(logsDir, 0750); err != nil {
 		return fmt.Errorf("unable to create directory %q, so no logs will be captured: %w", logsDir, err)
 	}

--- a/internal/envoy/debug/lsof.go
+++ b/internal/envoy/debug/lsof.go
@@ -46,7 +46,7 @@ type OpenFileStat struct {
 // enableOpenFilesDataCollection is a preset option that registers collection of statistics of files opened by envoy
 // instance(s).
 func enableOpenFilesDataCollection(r *envoy.Runtime) error {
-	lsofDir := filepath.Join(r.GetWorkingDir(), "lsof")
+	lsofDir := filepath.Join(r.GetRunDir(), "lsof")
 	if err := os.MkdirAll(lsofDir, 0750); err != nil {
 		return fmt.Errorf("unable to create directory %q, so lsof will not be captured: %w", lsofDir, err)
 	}

--- a/internal/envoy/debug/node.go
+++ b/internal/envoy/debug/node.go
@@ -32,7 +32,7 @@ import (
 
 // enableNodeCollection is a preset option that registers collection of node level information for debugging
 func enableNodeCollection(r *envoy.Runtime) error {
-	nodeDir := filepath.Join(r.GetWorkingDir(), "node")
+	nodeDir := filepath.Join(r.GetRunDir(), "node")
 	if err := os.MkdirAll(nodeDir, 0750); err != nil {
 		return fmt.Errorf("unable to create directory %q, so node data will not be captured: %w", nodeDir, err)
 	}

--- a/internal/envoy/run.go
+++ b/internal/envoy/run.go
@@ -30,7 +30,7 @@ func (r *Runtime) Run(ctx context.Context, args []string) (err error) {
 	// We can't use CommandContext even if that seems correct here. The reason is that we need to invoke preTerminate
 	// handlers, and they expect the process to still be running. For example, this allows admin API hooks.
 	cmd := exec.Command(r.opts.EnvoyPath, args...) // #nosec -> users can run whatever binary they like!
-	cmd.Dir = r.opts.WorkingDir
+	cmd.Dir = r.workingDir
 	cmd.Stdout = r.Out
 	cmd.Stderr = r.Err
 	cmd.SysProcAttr = sysProcAttr()
@@ -52,9 +52,7 @@ func (r *Runtime) Run(ctx context.Context, args []string) (err error) {
 	}
 
 	// Print the process line to the console for user knowledge and parsing convenience
-	a := strings.Join(append([]string{r.opts.EnvoyPath}, args...), " ") // ensures no trailing space on empty args
-	fmt.Fprintln(r.Out, "starting:", a)                                 //nolint
-	fmt.Fprintln(r.Out, "working directory:", cmd.Dir)                  //nolint
+	fmt.Fprintln(r.Out, "starting:", strings.Join(r.cmd.Args, " ")) //nolint
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("unable to start Envoy process: %w", err)
 	}

--- a/internal/envoy/run.go
+++ b/internal/envoy/run.go
@@ -30,7 +30,6 @@ func (r *Runtime) Run(ctx context.Context, args []string) (err error) {
 	// We can't use CommandContext even if that seems correct here. The reason is that we need to invoke preTerminate
 	// handlers, and they expect the process to still be running. For example, this allows admin API hooks.
 	cmd := exec.Command(r.opts.EnvoyPath, args...) // #nosec -> users can run whatever binary they like!
-	cmd.Dir = r.workingDir
 	cmd.Stdout = r.Out
 	cmd.Stderr = r.Err
 	cmd.SysProcAttr = sysProcAttr()

--- a/internal/envoy/run_test.go
+++ b/internal/envoy/run_test.go
@@ -36,8 +36,7 @@ func TestRuntime_Run(t *testing.T) {
 	defer removeTempDir()
 
 	runsDir := filepath.Join(tempDir, "runs")
-	fakeTimestamp := "1619574747231823000"
-	runDir := filepath.Join(runsDir, fakeTimestamp)
+	runDir := filepath.Join(runsDir, "1619574747231823000") // fake a realistic value
 	adminFlag := fmt.Sprintf("--admin-address-path %s/admin-address.txt", runDir)
 
 	// "quiet" as we aren't testing the environment envoy runs in
@@ -110,7 +109,7 @@ func TestRuntime_Run(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 1, len(files))
 			archive := filepath.Join(runsDir, files[0].Name())
-			require.Equal(t, filepath.Join(runsDir, fakeTimestamp+".tar.gz"), archive)
+			require.Equal(t, runDir+".tar.gz", archive)
 
 			// Cleanup for the next run
 			require.NoError(t, os.Remove(archive))

--- a/internal/envoy/run_test.go
+++ b/internal/envoy/run_test.go
@@ -37,7 +37,8 @@ func TestRuntime_Run(t *testing.T) {
 
 	runsDir := filepath.Join(tempDir, "runs")
 	fakeTimestamp := "1619574747231823000"
-	workingDir := filepath.Join(runsDir, fakeTimestamp)
+	runDir := filepath.Join(runsDir, fakeTimestamp)
+	adminFlag := fmt.Sprintf("--admin-address-path %s/admin-address.txt", runDir)
 
 	// "quiet" as we aren't testing the environment envoy runs in
 	fakeEnvoy := filepath.Join(tempDir, "quiet")
@@ -54,21 +55,17 @@ func TestRuntime_Run(t *testing.T) {
 		{
 			name: "GetEnvoy Ctrl-C",
 			// Don't warn the user when they exited the process
-			expectedStdout: fmt.Sprintf(`starting: %s
-working directory: %s
-`, fakeEnvoy, workingDir),
+			expectedStdout: fmt.Sprintln("starting:", fakeEnvoy, adminFlag),
 			expectedStderr: "started\ncaught SIGINT\n",
 			expectedHooks:  []string{"preStart", "preTermination", "postTermination"},
 		},
 		// We don't test envoy dying from an external signal as it isn't reported back to the getenvoy process and
 		// Envoy returns exit status zero on anything except kill -9. We can't test kill -9 with a fake shell script.
 		{
-			name:      "Envoy exited with error",
-			terminate: func() { time.Sleep(time.Millisecond * 100) },
-			args:      []string{"quiet_exit=3"},
-			expectedStdout: fmt.Sprintf(`starting: %s quiet_exit=3
-working directory: %s
-`, fakeEnvoy, workingDir),
+			name:           "Envoy exited with error",
+			terminate:      func() { time.Sleep(time.Millisecond * 100) },
+			args:           []string{"quiet_exit=3"},
+			expectedStdout: fmt.Sprintln("starting:", fakeEnvoy, "quiet_exit=3", adminFlag),
 			expectedStderr: "started\n",
 			expectedErr:    "envoy exited with status: 3",
 			expectedHooks:  []string{"preStart"},
@@ -78,8 +75,8 @@ working directory: %s
 	for _, tt := range tests {
 		tc := tt
 		t.Run(tc.name, func(t *testing.T) {
-			o := &globals.RunOpts{EnvoyPath: fakeEnvoy, WorkingDir: workingDir}
-			require.NoError(t, os.MkdirAll(workingDir, 0750))
+			o := &globals.RunOpts{EnvoyPath: fakeEnvoy, RunDir: runDir}
+			require.NoError(t, os.MkdirAll(runDir, 0750))
 
 			stdout := new(bytes.Buffer)
 			stderr := new(bytes.Buffer)

--- a/internal/envoy/runtime.go
+++ b/internal/envoy/runtime.go
@@ -35,8 +35,6 @@ func NewRuntime(opts *globals.RunOpts) *Runtime {
 // Runtime manages an Envoy lifecycle
 type Runtime struct {
 	opts *globals.RunOpts
-	// workingDir is overridable for tests, and controls the "Dir" of exec.Cmd
-	workingDir string
 
 	cmd *exec.Cmd
 	Out io.Writer

--- a/internal/envoy/runtime.go
+++ b/internal/envoy/runtime.go
@@ -26,7 +26,7 @@ import (
 	"github.com/tetratelabs/getenvoy/internal/globals"
 )
 
-// NewRuntime creates a new Runtime that runs envoy in globals.RunOpts WorkingDir
+// NewRuntime creates a new Runtime that runs envoy in globals.RunOpts RunDir
 // opts allows a user running envoy to control the working directory by ID or path, allowing explicit cleanup.
 func NewRuntime(opts *globals.RunOpts) *Runtime {
 	return &Runtime{opts: opts}
@@ -35,6 +35,8 @@ func NewRuntime(opts *globals.RunOpts) *Runtime {
 // Runtime manages an Envoy lifecycle
 type Runtime struct {
 	opts *globals.RunOpts
+	// workingDir is overridable for tests, and controls the "Dir" of exec.Cmd
+	workingDir string
 
 	cmd *exec.Cmd
 	Out io.Writer
@@ -49,9 +51,9 @@ type Runtime struct {
 	preStart, preTermination, postTermination []func() error
 }
 
-// GetWorkingDir returns the run-specific directory files can be written to.
-func (r *Runtime) GetWorkingDir() string {
-	return r.opts.WorkingDir
+// GetRunDir returns the run-specific directory files can be written to.
+func (r *Runtime) GetRunDir() string {
+	return r.opts.RunDir
 }
 
 // GetAdminAddress returns the current admin address in host:port format, or empty if not yet available.

--- a/internal/envoy/start.go
+++ b/internal/envoy/start.go
@@ -55,7 +55,7 @@ func (r *Runtime) ensureAdminAddressPath() error {
 		}
 	}
 	// Envoy's run directory is mutable, so it is fine to write the admin address there.
-	r.cmd.Args = append(r.cmd.Args, flag, "admin-address.txt")
-	r.adminAddressPath = filepath.Join(r.opts.WorkingDir, "admin-address.txt")
+	r.adminAddressPath = filepath.Join(r.opts.RunDir, "admin-address.txt")
+	r.cmd.Args = append(r.cmd.Args, flag, r.adminAddressPath)
 	return nil
 }

--- a/internal/envoy/termination.go
+++ b/internal/envoy/termination.go
@@ -48,19 +48,19 @@ func (r *Runtime) handlePostTermination() error {
 		}
 	}
 
-	if r.opts.DontArchiveWorkingDir {
+	if r.opts.DontArchiveRunDir {
 		return nil
 	}
 
 	// Given ~/.getenvoy/debug/1620955405964267000
-	dirName := filepath.Dir(r.GetWorkingDir())              // ~/.getenvoy/debug
-	baseName := filepath.Base(r.GetWorkingDir())            // 1620955405964267000
+	dirName := filepath.Dir(r.GetRunDir())                  // ~/.getenvoy/debug
+	baseName := filepath.Base(r.GetRunDir())                // 1620955405964267000
 	targzName := filepath.Join(dirName, baseName+".tar.gz") // ~/.getenvoy/debug/1620955405964267000.tar.gz
 
-	if err := tar.TarGz(targzName, r.GetWorkingDir()); err != nil {
-		return fmt.Errorf("unable to archive run directory %v: %w", r.GetWorkingDir(), err)
+	if err := tar.TarGz(targzName, r.GetRunDir()); err != nil {
+		return fmt.Errorf("unable to archive run directory %v: %w", r.GetRunDir(), err)
 	}
-	return os.RemoveAll(r.GetWorkingDir())
+	return os.RemoveAll(r.GetRunDir())
 }
 
 // RegisterPreTermination registers the passed functions to be run after Envoy has started

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -24,12 +24,14 @@ import (
 type RunOpts struct {
 	// EnvoyPath is the exec.Cmd path to "envoy". Defaults to "$HomeDir/versions/$version/bin/envoy"
 	EnvoyPath string
-	// WorkingDir is the working directory of EnvoyPath and includes any generated configuration or debug files.
-	// Upon termination, this directory is archived as "../$(basename $WorkingDir).tar.gz"
+	// RunDir is the location any generated configuration or debug files are written.
+	// This is not Envoy's working directory, which remains the same as the $PWD of getenvoy.
+	//
+	// Upon termination, this directory is archived as "../$(basename $RunDir).tar.gz"
 	// Defaults to "$HomeDir/runs/$epochtime"
-	WorkingDir string
-	// DontArchiveWorkingDir is used in testing and prevents archiving the WorkingDir
-	DontArchiveWorkingDir bool
+	RunDir string
+	// DontArchiveRunDir is used in testing and prevents archiving the RunDir
+	DontArchiveRunDir bool
 }
 
 // GlobalOpts represents options that affect more than one getenvoy commands.

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -110,7 +110,6 @@ func requireFakeEnvoyTarGz(t *testing.T, v string) []byte {
 	fakeEnvoy := []byte(`#!/bin/sh
 set -ue
 # Echo invocation context to stdout and fake stderr to ensure it is not combined into stdout.
-echo envoy wd: $PWD
 echo envoy bin: $0
 echo envoy args: $@
 echo >&2 envoy stderr


### PR DESCRIPTION
This makes sure Envoy is run in the current working directory, so that
it is easier to use and configuration can locate relative paths.

Fixes #263