### PR TITLE
Writes envoy.pid and verifies Envoy is killed in e2e tests

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -66,6 +66,7 @@ jobs:
         run: make e2e
 
       - name: "Generate coverage report" # only once (not per OS)
+        if: runner.os == 'Linux'
         run: make coverage
 
       - name: "Upload coverage report" # only on master push and only once (not per OS)

--- a/e2e/getenvoy_run_test.go
+++ b/e2e/getenvoy_run_test.go
@@ -16,19 +16,22 @@ package e2e
 
 import (
 	"bufio"
+	"context"
 	_ "embed" // We embed the config files to make them easier to copy
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
+	"github.com/shirou/gopsutil/v3/process"
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/getenvoy/internal/moreos"
 	"github.com/tetratelabs/getenvoy/internal/tar"
 	"github.com/tetratelabs/getenvoy/internal/test/morerequire"
 )
@@ -39,6 +42,8 @@ var (
 	staticFilesystemConfig  []byte
 	adminAddressPathPattern = regexp.MustCompile(`--admin-address-path ([^ ]+)`)
 	envoyStartedLine        = "starting main dispatch loop"
+	// minRunArgs is the minimal config needed to run Envoy 1.18+, non-windows <1.18 need access_log_path: '/dev/stdout'
+	minRunArgs = []string{"run", "--config-yaml", "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 0}}}"}
 )
 
 // TestGetEnvoyRun runs the equivalent of "getenvoy run"
@@ -47,13 +52,10 @@ var (
 func TestGetEnvoyRun(t *testing.T) {
 	t.Parallel() // uses random ports so safe to run parallel
 
-	// Below is the minimal config needed to run Envoy 1.18+, non-windows <1.18 need access_log_path: '/dev/stdout'
-	args := []string{"run", "--config-yaml", "admin: {address: {socket_address: {address: '127.0.0.1', port_value: 0}}}"}
+	cmd, cleanup := envoyRunTest(t, nil, minRunArgs...)
+	defer cleanup()
 
-	c, runArchive := envoyRunTest(t, nil, args...)
-	defer os.Remove(runArchive) //nolint
-
-	verifyRunArchive(t, runArchive, c)
+	verifyRunArchive(t, cmd)
 }
 
 func TestGetEnvoyRun_StaticFilesystem(t *testing.T) {
@@ -66,28 +68,30 @@ func TestGetEnvoyRun_StaticFilesystem(t *testing.T) {
 	responseFromRunDirectory := []byte("foo")
 	require.NoError(t, os.WriteFile("response.txt", responseFromRunDirectory, 0600))
 
-	_, runArchive := envoyRunTest(t, func(c *getEnvoy, a *adminClient) {
-		mainURL, err := a.getMainListenerURL()
-		require.NoError(t, err, `couldn't read mainURL after running [%v]`, c)
+	_, cleanup := envoyRunTest(t, func(ctx context.Context, c *getEnvoy, a *adminClient) {
+		mainURL, err := a.getMainListenerURL(ctx)
+		require.NoError(t, err, "couldn't read mainURL after running [%v]", c)
 
-		body, err := httpGet(mainURL)
-		require.NoError(t, err, `couldn't read %s after running [%v]`, mainURL, c)
+		body, err := httpGet(ctx, mainURL)
+		require.NoError(t, err, "couldn't read %s after running [%v]", mainURL, c)
 
 		// If this passes, we know Envoy is running in the current directory, so can resolve relative configuration.
-		require.Equal(t, responseFromRunDirectory, body, `unexpected content in %s after running [%v]`, mainURL, c)
+		require.Equal(t, responseFromRunDirectory, body, "unexpected content in %s after running [%v]", mainURL, c)
 	}, "run", "-c", "envoy.yaml")
 
-	require.NoError(t, os.Remove(runArchive))
+	cleanup()
 }
 
-// envoyRunTest runs the given args and the test function once envoy is available. This returns the command and the path
-// to the run archive.
+// envoyRunTest runs the given args and the test function once envoy is available. This returns the command and a
+// function to remove the run archive.
 //
 // If the process successfully starts, this blocks until the adminClient is available.  The process is interrupted when
 // the test completes, or a timeout occurs.
-func envoyRunTest(t *testing.T, test func(*getEnvoy, *adminClient), args ...string) (*getEnvoy, string) {
-	c, cancel := newGetEnvoy(args...)
+func envoyRunTest(t *testing.T, test func(context.Context, *getEnvoy, *adminClient), args ...string) (*getEnvoy, func()) {
+	ctx, cancel := context.WithTimeout(context.Background(), runTimeout)
 	defer cancel()
+
+	c := newGetEnvoy(ctx, args...)
 
 	stdout, out := c.cmd.StdoutPipe()
 	outLines := bufio.NewScanner(stdout)
@@ -100,7 +104,7 @@ func envoyRunTest(t *testing.T, test func(*getEnvoy, *adminClient), args ...stri
 	err = c.cmd.Start()
 	require.NoError(t, err)
 
-	log.Printf(`waiting for getenvoy stdout to match %q after running [%v]`, adminAddressPathPattern, c)
+	log.Printf("waiting for getenvoy stdout to match %q after running [%v]", adminAddressPathPattern, c)
 	var adminAddressPath string
 	go func() {
 		for outLines.Scan() {
@@ -111,7 +115,8 @@ func envoyRunTest(t *testing.T, test func(*getEnvoy, *adminClient), args ...stri
 			// contents until Envoy creates it. This only ensures we know the file name.
 			if adminAddressPathPattern.MatchString(l) {
 				adminAddressPath = adminAddressPathPattern.FindStringSubmatch(l)[1]
-				log.Printf(`waiting for Envoy stdout to match %q after running [%v]`, envoyStartedLine, c)
+				c.runDir = filepath.Dir(adminAddressPath)
+				log.Printf("waiting for Envoy stdout to match %q after running [%v]", envoyStartedLine, c)
 			}
 		}
 	}()
@@ -123,8 +128,9 @@ func envoyRunTest(t *testing.T, test func(*getEnvoy, *adminClient), args ...stri
 
 			// When we get to this line, we can assume Envoy started properly. Run the test
 			if strings.Contains(l, envoyStartedLine) {
-				require.NotEmpty(t, adminAddressPath, "expected adminAddressPath to be set")
-				go runTestAndInterruptEnvoy(t, c, adminAddressPath, test) // don't block stderr when the test is running
+				require.NotEmpty(t, c.runDir, "expected adminAddressPath to be set")
+				requireEnvoyPid(t, c)                        // check here to avoid race condition
+				go runTestAndInterruptEnvoy(ctx, t, c, test) // don't block printing stderr!
 			}
 		}
 	}()
@@ -132,41 +138,59 @@ func envoyRunTest(t *testing.T, test func(*getEnvoy, *adminClient), args ...stri
 	err = c.cmd.Wait() // This won't hang forever because newGetEnvoy started it with a context timeout!
 	require.NoError(t, err)
 
-	// return the run archive location
-	return c, filepath.Dir(adminAddressPath) + ".tar.gz"
-}
+	// Ensure the Envoy process was terminated
+	_, err = process.NewProcessWithContext(ctx, c.envoyPid) // because os.FindProcess is no-op in Linux!
+	require.Error(t, err, "expected GetEnvoy to terminate Envoy after running [%v]", c)
 
-func runTestAndInterruptEnvoy(t *testing.T, c *getEnvoy, adminAddressPath string, test func(*getEnvoy, *adminClient)) {
-	defer func() {
-		log.Printf(`shutting down Envoy after running [%v]`, c)
-		_ = c.cmd.Process.Signal(syscall.SIGTERM)
-	}()
-	a := requireEnvoyReady(t, adminAddressPath, c)
-	if test != nil {
-		test(c, a)
+	return c, func() {
+		// this may not be present if the process was kill -9'd so don't error
+		os.Remove(c.runDir + ".tar.gz") //nolint
 	}
 }
 
-func requireEnvoyReady(t *testing.T, adminAddressPath string, c interface{}) *adminClient {
-	adminAddress, err := os.ReadFile(adminAddressPath) //nolint:gosec
-	require.NoError(t, err, `error reading admin address file %q after running [%v]`, adminAddressPath, c)
+func runTestAndInterruptEnvoy(ctx context.Context, t *testing.T, c *getEnvoy, test func(context.Context, *getEnvoy, *adminClient)) {
+	defer func() {
+		log.Printf("shutting down Envoy after running [%v]", c)
+		require.NoError(t, moreos.Interrupt(c.cmd.Process), "error shutting down Envoy after running [%v]", c)
+	}()
+	a := requireEnvoyReady(ctx, t, c)
+	if test != nil {
+		test(ctx, c, a)
+	}
+}
 
-	log.Printf(`waiting for Envoy adminClient to connect after running [%v]`, c)
+func requireEnvoyReady(ctx context.Context, t *testing.T, c *getEnvoy) *adminClient {
+	adminAddressPath := filepath.Join(c.runDir, "admin-address.txt")
+	adminAddress, err := os.ReadFile(adminAddressPath) //nolint:gosec
+	require.NoError(t, err, "error reading admin address file %q after running [%v]", adminAddressPath, c)
+
+	log.Printf("waiting for Envoy adminClient to connect after running [%v]", c)
 	envoyClient, err := newAdminClient(string(adminAddress))
-	require.NoError(t, err, `error from Envoy adminClient %s after running [%v]`, adminAddress, c)
+	require.NoError(t, err, "error from Envoy adminClient %s after running [%v]", adminAddress, c)
 	require.Eventually(t, func() bool {
-		ready, err := envoyClient.isReady()
-		return err == nil && ready
-	}, 1*time.Minute, 100*time.Millisecond, `Envoy adminClient %s never ready after running [%v]`, adminAddress, c)
+		return envoyClient.isReady(ctx)
+	}, 1*time.Minute, 100*time.Millisecond, "Envoy adminClient %s never ready after running [%v]", adminAddress, c)
 
 	return envoyClient
 }
 
+// requireEnvoyPid ensures $runDir/envoy.pid was written and is valid
+func requireEnvoyPid(t *testing.T, c *getEnvoy) {
+	pidPath := filepath.Join(c.runDir, "envoy.pid")
+	pidTxt, err := os.ReadFile(pidPath)
+	require.NoError(t, err, "couldn't read %s after running [%v]", pidPath, c)
+	pid, err := strconv.Atoi(string(pidTxt))
+	require.NoError(t, err, "invalid Envoy pid in %s after running [%v]", pidPath, c)
+	require.Greater(t, pid, 1, "invalid Envoy pid %s after running [%v]", pid, c)
+	c.envoyPid = int32(pid)
+}
+
 // Run deletes the run directory after making a tar.gz with the same name. This extracts it and tests the contents.
-func verifyRunArchive(t *testing.T, runArchive string, c interface{}) {
+func verifyRunArchive(t *testing.T, c *getEnvoy) {
 	runDir, removeRunDir := morerequire.RequireNewTempDir(t)
 	defer removeRunDir()
 
+	runArchive := c.runDir + ".tar.gz"
 	src, err := os.Open(runArchive)
 	require.NoError(t, err, "error opening %s after shutdown [%v]", runArchive, c)
 
@@ -177,7 +201,7 @@ func verifyRunArchive(t *testing.T, runArchive string, c interface{}) {
 	for _, filename := range []string{"stdout.log", "stderr.log", "config_dump.json", "stats.json"} {
 		path := filepath.Join(runDir, filename)
 		f, err := os.Stat(path)
-		require.NoError(t, err, `run archive %s doesn't contain %s after shutdown [%v]`, runArchive, filename, c)
-		require.NotEmpty(t, f.Size(), `%s was empty after shutdown [%v]`, filename, c)
+		require.NoError(t, err, "run archive %s doesn't contain %s after shutdown [%v]", runArchive, filename, c)
+		require.NotEmpty(t, f.Size(), "%s was empty after shutdown [%v]", filename, c)
 	}
 }

--- a/e2e/getenvoy_use_test.go
+++ b/e2e/getenvoy_use_test.go
@@ -58,10 +58,11 @@ func TestGetEnvoyUse(t *testing.T) {
 }
 
 func TestGetEnvoyUse_UnknownVersion(t *testing.T) {
-	stdout, stderr, err := getEnvoyExec("use", "1.1.1")
+	v := "1.1.1"
+	stdout, stderr, err := getEnvoyExec("use", v)
 
 	require.EqualError(t, err, "exit status 1")
 	require.Empty(t, stdout)
-	require.Equal(t, fmt.Sprintf(`error: couldn't find version "1.1.1" for platform "%s/%s"
-`, runtime.GOOS, runtime.GOARCH), stderr)
+	require.Equal(t, fmt.Sprintf(`error: couldn't find version "%s" for platform "%s/%s"
+`, v, runtime.GOOS, runtime.GOARCH), stderr)
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -48,10 +48,10 @@ The version to use is downloaded and installed, if necessary.
 Envoy interprets the '[arguments...]' and runs in the current working
 directory (aka $CWD) until getenvoy is interrupted (ex Ctrl+C, Ctrl+Break).
 
-Console output is captured as "stdout.log" and "stderr.log" in the run
-directory (` + "`$GETENVOY_HOME/runs/$epochtime`" + `). When interrupted,
-shutdown hooks write files, including admin endpoints, network and process
-state. Upon exit, these zip into ` + "`$GETENVOY_HOME/runs/$epochtime.tar.gz`",
+Envoy's process ID and console output write to "envoy.pid", stdout.log" and
+"stderr.log" in the run directory (` + "`$GETENVOY_HOME/runs/$epochtime`" + `).
+When interrupted, shutdown hooks write files including network and process
+state. On exit, these archive into ` + "`$GETENVOY_HOME/runs/$epochtime.tar.gz`",
 		Before: func(c *cli.Context) error {
 			if err := os.MkdirAll(o.HomeDir, 0750); err != nil {
 				return NewValidationError(err.Error())

--- a/internal/cmd/testdata/getenvoy_run_help.txt
+++ b/internal/cmd/testdata/getenvoy_run_help.txt
@@ -16,7 +16,7 @@ DESCRIPTION:
    Envoy interprets the '[arguments...]' and runs in the current working
    directory (aka $CWD) until getenvoy is interrupted (ex Ctrl+C, Ctrl+Break).
    
-   Console output is captured as "stdout.log" and "stderr.log" in the run
-   directory (`$GETENVOY_HOME/runs/$epochtime`). When interrupted,
-   shutdown hooks write files, including admin endpoints, network and process
-   state. Upon exit, these zip into `$GETENVOY_HOME/runs/$epochtime.tar.gz`
+   Envoy's process ID and console output write to "envoy.pid", stdout.log" and
+   "stderr.log" in the run directory (`$GETENVOY_HOME/runs/$epochtime`).
+   When interrupted, shutdown hooks write files including network and process
+   state. On exit, these archive into `$GETENVOY_HOME/runs/$epochtime.tar.gz`

--- a/internal/envoy/runtime.go
+++ b/internal/envoy/runtime.go
@@ -37,7 +37,7 @@ const (
 // NewRuntime creates a new Runtime that runs envoy in globals.RunOpts RunDir
 // opts allows a user running envoy to control the working directory by ID or path, allowing explicit cleanup.
 func NewRuntime(opts *globals.RunOpts) *Runtime {
-	return &Runtime{opts: opts}
+	return &Runtime{opts: opts, pidPath: filepath.Join(opts.RunDir, "envoy.pid")}
 }
 
 // Runtime manages an Envoy lifecycle
@@ -48,7 +48,7 @@ type Runtime struct {
 	Out io.Writer
 	Err io.Writer
 
-	adminAddress, adminAddressPath string
+	adminAddress, adminAddressPath, pidPath string
 
 	// FakeInterrupt is exposed for unit tests to pretend "getenvoy run" received a Ctrl+C or Ctrl+Break.
 	// End-to-end tests should kill the getenvoy process to achieve the same.

--- a/internal/envoy/runtime_test.go
+++ b/internal/envoy/runtime_test.go
@@ -101,3 +101,8 @@ func TestEnsureAdminAddressPath_ValidateExisting(t *testing.T) {
 		})
 	}
 }
+
+func TestPidFilePath(t *testing.T) {
+	r := NewRuntime(&globals.RunOpts{RunDir: "run"})
+	require.Equal(t, filepath.Join("run", "envoy.pid"), r.pidPath)
+}

--- a/internal/envoy/shutdown.go
+++ b/internal/envoy/shutdown.go
@@ -20,9 +20,9 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 
+	"github.com/tetratelabs/getenvoy/internal/moreos"
 	"github.com/tetratelabs/getenvoy/internal/tar"
 )
 
@@ -59,7 +59,9 @@ func (r *Runtime) handleShutdown(ctx context.Context) {
 func (r *Runtime) interruptEnvoy() {
 	p := r.cmd.Process
 	fmt.Fprintf(r.Out, "sending interrupt to envoy (pid=%d)\n", p.Pid) //nolint
-	_ = p.Signal(syscall.SIGINT)
+	if err := moreos.Interrupt(p); err != nil {
+		fmt.Fprintln(r.Out, "warning:", err) //nolint
+	}
 }
 
 func (r *Runtime) archiveRunDir() error {

--- a/internal/moreos/moreos.go
+++ b/internal/moreos/moreos.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build !linux
-
 package moreos
 
 import (

--- a/internal/moreos/moreos.go
+++ b/internal/moreos/moreos.go
@@ -12,20 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package e2e
+// +build !linux
+
+package moreos
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
+	"os"
+	"syscall"
 )
 
-func TestGetEnvoyVersion(t *testing.T) {
-	t.Parallel()
+// ProcessGroupAttr sets attributes that ensure exec.Cmd doesn't propagate signals from getenvoy by default.
+// This is used to ensure shutdown hooks can apply
+func ProcessGroupAttr() *syscall.SysProcAttr {
+	return processGroupAttr() // un-exported to prevent godoc drift
+}
 
-	stdout, stderr, err := getEnvoyExec("--version")
-
-	require.Regexp(t, `^getenvoy version ([^\s]+)\n$`, stdout)
-	require.Empty(t, stderr)
-	require.NoError(t, err)
+// Interrupt attempts to interrupt the process. It doesn't necessarily kill it.
+func Interrupt(p *os.Process) error {
+	return interrupt(p) // un-exported to prevent godoc drift
 }

--- a/internal/moreos/proc.go
+++ b/internal/moreos/proc.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Tetrate
+// Copyright 2021 Tetrate
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,15 +14,17 @@
 
 // +build !linux
 
-package envoy
+package moreos
 
 import (
+	"os"
 	"syscall"
 )
 
-func sysProcAttr() *syscall.SysProcAttr {
-	// TODO: Add a test for "getenvoy run" kill -9, that checks if the child envoy process remains running.
-	return &syscall.SysProcAttr{
-		Setpgid: true, // equivalent to setpgrp() syscall
-	}
+func processGroupAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}
+
+func interrupt(p *os.Process) error {
+	return p.Signal(syscall.SIGINT)
 }

--- a/internal/moreos/proc_linux.go
+++ b/internal/moreos/proc_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Tetrate
+// Copyright 2021 Tetrate
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envoy
+package moreos
 
-import "syscall"
+import (
+	"os"
+	"syscall"
+)
 
-func sysProcAttr() *syscall.SysProcAttr {
-	return &syscall.SysProcAttr{
-		Setpgid:   true,            // equivalent to setpgrp() syscall
-		Pdeathsig: syscall.SIGTERM, // ensure the child Envoy process is cleaned up even if we die
-	}
+func processGroupAttr() *syscall.SysProcAttr {
+	// Pdeathsig aims to ensure the process group is cleaned up even if this process dies
+	return &syscall.SysProcAttr{Setpgid: true, Pdeathsig: syscall.SIGTERM}
+}
+
+func interrupt(p *os.Process) error {
+	return p.Signal(syscall.SIGINT)
 }


### PR DESCRIPTION
This creates a foundation for future work by ensure Envoy is killed as
expected. Before, we weren't checking at all or weren't checking
propertly depending on the test.

This also does more hardening around timeouts by sharing a single parent
context during e2e run tests.