### PR TITLE
Permits using a debug version

### DIFF
--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -66,7 +66,7 @@ const (
 
 var (
 	// EnvoyVersionPattern is used to validate versions and is the same pattern as release-versions-schema.json.
-	EnvoyVersionPattern = regexp.MustCompile(`^[1-9][0-9]*\.[0-9]+\.[0-9]+$`)
+	EnvoyVersionPattern = regexp.MustCompile(`^[1-9][0-9]*\.[0-9]+\.[0-9]+(_debug)?$`)
 	// CurrentPlatform is the platform of the current process. This is used as a key in EnvoyVersion.Tarballs.
 	CurrentPlatform = version.Platform(runtime.GOOS + "/" + runtime.GOARCH)
 )

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/tetratelabs/getenvoy/internal/globals"
 	"github.com/tetratelabs/getenvoy/internal/moreos"
 	"github.com/tetratelabs/getenvoy/internal/tar"
 	"github.com/tetratelabs/getenvoy/internal/test/morerequire"
@@ -94,7 +95,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		require.True(s.t, strings.HasSuffix(subpath, archiveFormat), "unexpected uri %q: expected archive suffix %q", subpath, archiveFormat)
 
 		v := strings.Split(subpath, "/")[0]
-		require.Regexpf(s.t, `^1\.[1-9][0-9]\.[0-9]+$`, v, "unsupported version in uri %q", subpath)
+		require.Regexpf(s.t, globals.EnvoyVersionPattern, v, "unsupported version in uri %q", subpath)
 
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write(s.fakeEnvoyTarGz)


### PR DESCRIPTION
    Permits using a debug version
    
Debug versions are massive (2GB) and not available for all platforms. However, if someone has a supported platform, they should be able to use them.
    
Ex. on ubuntu:20.04
```bash
$ export ENVOY_VERSIONS_URL=https://archive.tetratelabs.io/envoy/envoy-versions_debug.json
$ getenvoy run --version
looking up latest version
downloading https://archive.tetratelabs.io/envoy/download/v1.18.3_debug/envoy-v1.18.3_debug-linux-amd64.tar.xz
starting: /root/.getenvoy/versions/1.18.3_debug/bin/envoy --version --admin-address-path /root/.getenvoy/runs/1624003987461190188/admin-address.txt

/root/.getenvoy/versions/1.18.3_debug/bin/envoy  version: 98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Clean/RELEASE/BoringSSL
$ find /root/.getenvoy/versions/1.18.3_debug/
/root/.getenvoy/versions/1.18.3_debug/
/root/.getenvoy/versions/1.18.3_debug/bin
/root/.getenvoy/versions/1.18.3_debug/bin/su-exec
/root/.getenvoy/versions/1.18.3_debug/bin/envoy
/root/.getenvoy/versions/1.18.3_debug/bin/envoy.dwp
```

See https://github.com/tetratelabs/archive-envoy/pull/7